### PR TITLE
Faster solve!: BLAS-friendly AIC layout + leaner filament kernels (5.4-8.0x)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,6 +64,10 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         env:
           BUILD_IS_PRODUCTION_BUILD: ${{ matrix.build_is_production_build }}
+          # Only Linux gets a virtual display, so runtests.jl skips the plotting tests
+          # elsewhere. Julia 1.12.7 precompiles the whole test environment up front,
+          # which loads GLMakie before that guard runs; keep it lazy off Linux.
+          JULIA_PKG_PRECOMPILE_AUTO: ${{ runner.os == 'Linux' && '1' || '0' }}
         with:
           coverage: false
           prefix: ${{ runner.os == 'Linux' && 'xvfb-run -a' || '' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,20 @@
   them when `table_format` differs from what the directory holds, so a dataset
   changes format without re-running the airfoil solver that produced it.
 
+### Fixed
+- The `Solver` docstring listed `type_initial_gamma_distribution` as `ELLIPTIC` and
+  `core_radius_fraction` as `1e-20`; the defaults are `ZEROS` and `0.05`.
+
 ### Changed
 - BREAKING: `BodyAerodynamics.AIC` is stored as `(n_panels, n_panels, 3)` instead of
   `(3, n_panels, n_panels)`, so each component slice `AIC[:, :, k]` is contiguous and
   the induced-velocity products reach BLAS `gemv` instead of the generic fallback.
   `solve!` is 3.1–5.3× faster (n=120, VSM: 26.1 ms → 4.9 ms inviscid, 21.1 ms →
   6.0 ms with polars). Code reading `AIC[k, i, j]` must become `AIC[i, j, k]`.
+- The filament induced-velocity kernels reuse the `r0`/`length` each `BoundFilament`
+  already stores, take the core-radius cutoff from `|r1.r0|/|r0|` without forming the
+  perpendicular vector, and defer the cross products that only one branch reads. Output
+  is bit-identical; `solve!` is a further 1.47-1.55x faster.
 - `read_node_table` parses into a preallocated matrix instead of `reduce(vcat, …)`
   over a generator, which was quadratic in the row count: ~21× faster on a 16 MB
   surface table (2.49 s → 0.12 s), benefiting every existing dataset.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
   changes format without re-running the airfoil solver that produced it.
 
 ### Changed
+- BREAKING: `BodyAerodynamics.AIC` is stored as `(n_panels, n_panels, 3)` instead of
+  `(3, n_panels, n_panels)`, so each component slice `AIC[:, :, k]` is contiguous and
+  the induced-velocity products reach BLAS `gemv` instead of the generic fallback.
+  `solve!` is 3.1–5.3× faster (n=120, VSM: 26.1 ms → 4.9 ms inviscid, 21.1 ms →
+  6.0 ms with polars). Code reading `AIC[k, i, j]` must become `AIC[i, j, k]`.
 - `read_node_table` parses into a preallocated matrix instead of `reduce(vcat, …)`
   over a generator, which was quadratic in the row count: ~21× faster on a 16 MB
   surface table (2.49 s → 0.12 s), benefiting every existing dataset.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,11 @@
   changes format without re-running the airfoil solver that produced it.
 
 ### Fixed
-- The `Solver` docstring listed `type_initial_gamma_distribution` as `ELLIPTIC` and
-  `core_radius_fraction` as `1e-20`; the defaults are `ZEROS` and `0.05`.
+- The `Solver` docstring quoted the `SolverSettings` defaults for
+  `type_initial_gamma_distribution` and `core_radius_fraction` (`ELLIPTIC`, `1e-20`)
+  instead of its own (`ZEROS`, `0.05`), and never said what `core_radius_fraction`
+  measures. It now documents the `Solver` defaults and cites Damiani et al. (2019) for
+  the 0.05 cut-off. The two structs still disagree on both values.
 
 ### Changed
 - BREAKING: `BodyAerodynamics.AIC` is stored as `(n_panels, n_panels, 3)` instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,17 @@
   `type_initial_gamma_distribution` and `core_radius_fraction` (`ELLIPTIC`, `1e-20`)
   instead of its own (`ZEROS`, `0.05`), and never said what `core_radius_fraction`
   measures. It now documents the `Solver` defaults and cites Damiani et al. (2019) for
-  the 0.05 cut-off. The two structs still disagree on both values.
+  the 0.05 cut-off.
 
 ### Changed
+- `SolverSettings` now defaults to the same values as `Solver`: `core_radius_fraction`
+  `1e-20` → `0.05` and `type_initial_gamma_distribution` `ELLIPTIC` → `ZEROS`. The 0.05
+  bound vortex core cut-off follows Damiani et al. (2019), "A Vortex Step Method for
+  Nonlinear Airfoil Polar Data as Implemented in KiteAeroDyn", and matches the upstream
+  `awegroup/Vortex-Step-Method` default; at `1e-20` the Biot-Savart singularity guard
+  never engaged. Coefficients are unchanged for well-separated geometry, since the guard
+  only triggers where a control point falls within 5% of a filament length of a bound
+  vortex, and every settings file shipped in `data/` sets both keys explicitly.
 - BREAKING: `BodyAerodynamics.AIC` is stored as `(n_panels, n_panels, 3)` instead of
   `(3, n_panels, n_panels)`, so each component slice `AIC[:, :, k]` is contiguous and
   the induced-velocity products reach BLAS `gemv` instead of the generic fallback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
   never engaged. Coefficients are unchanged for well-separated geometry, since the guard
   only triggers where a control point falls within 5% of a filament length of a bound
   vortex, and every settings file shipped in `data/` sets both keys explicitly.
-- BREAKING: `BodyAerodynamics.AIC` is stored as `(n_panels, n_panels, 3)` instead of
+- `BodyAerodynamics.AIC` is stored as `(n_panels, n_panels, 3)` instead of
   `(3, n_panels, n_panels)`, so each component slice `AIC[:, :, k]` is contiguous and
   the induced-velocity products reach BLAS `gemv` instead of the generic fallback.
   `solve!` is 3.1–5.3× faster (n=120, VSM: 26.1 ms → 4.9 ms inviscid, 21.1 ms →

--- a/data/TUDELFT_V3_KITE/vsm_settings.yaml
+++ b/data/TUDELFT_V3_KITE/vsm_settings.yaml
@@ -69,7 +69,7 @@ solver_settings:
     artificial_damping: false        # Enable artificial damping for unstable cases
     k2: 0.1                          # 2nd-order damping coefficient
     k4: 0.0                          # 4th-order damping coefficient
-    core_radius_fraction: 0.05      # Vortex core radius (fraction of chord)
+    core_radius_fraction: 0.05      # Vortex core radius (fraction of filament length)
     
     # --- Initial Conditions ---
     type_initial_gamma_distribution: ELLIPTIC  # Starting circulation distribution

--- a/data/TUDELFT_V3_KITE/vsm_settings_coarse.yaml
+++ b/data/TUDELFT_V3_KITE/vsm_settings_coarse.yaml
@@ -73,7 +73,7 @@ solver_settings:
   artificial_damping: false # Enable artificial damping for unstable cases
   k2: 0.1 # 2nd-order damping coefficient
   k4: 0.0 # 4th-order damping coefficient
-  core_radius_fraction: 1e-20 # Vortex core radius (fraction of chord)
+  core_radius_fraction: 1e-20 # Vortex core radius (fraction of filament length)
 
   # --- Initial Conditions ---
   type_initial_gamma_distribution: ELLIPTIC # Starting circulation distribution

--- a/data/pyramid_model/vsm_settings.yaml
+++ b/data/pyramid_model/vsm_settings.yaml
@@ -68,7 +68,7 @@ solver_settings:
     artificial_damping: false        # Enable artificial damping for unstable cases
     k2: 0.0                          # 2nd-order damping coefficient
     k4: 0.0                          # 4th-order damping coefficient
-    core_radius_fraction: 0.05      # Vortex core radius (fraction of chord)
+    core_radius_fraction: 0.05      # Vortex core radius (fraction of filament length)
     
     # --- Initial Conditions ---
     type_initial_gamma_distribution: ELLIPTIC  # Starting circulation distribution

--- a/src/body_aerodynamics.jl
+++ b/src/body_aerodynamics.jl
@@ -16,7 +16,8 @@ Main structure for calculating aerodynamic properties of bodies. Use the constru
 - `alpha_dist::MVector{P, Float64}` = zeros(Float64, P)
 - `v_a_dist::MVector{P, Float64}` = zeros(Float64, P)
 - `work_vectors`::NTuple{10, MVec3} = ntuple(_ -> zeros(MVec3), 10)
-- `AIC::Array{Float64, 3}` = zeros(3, P, P)
+- `AIC::Array{Float64, 3}` = zeros(P, P, 3): influence coefficients, component last so
+                        that each `AIC[:, :, k]` slice is a contiguous BLAS matrix
 - `projected_area::Float64` = 1.0: The area projected onto the xy-plane of the kite body reference frame [m²]
 - `c_ref::Float64` = 1.0: Reference chord length (max panel chord) [m]
 - `y::MVector{P, Float64}` = MVector{P,Float64}(zeros(P))
@@ -35,7 +36,7 @@ Main structure for calculating aerodynamic properties of bodies. Use the constru
     alpha_dist::MVector{P, T} = zeros(MVector{P, T})
     v_a_dist::MVector{P, T} = zeros(MVector{P, T})
     work_vectors::NTuple{10, MVector{3, T}} = ntuple(_ -> zeros(MVector{3, T}), 10)
-    AIC::Array{T, 3} = zeros(T, 3, P, P)
+    AIC::Array{T, 3} = zeros(T, P, P, 3)
     projected_area::T = one(T)
     c_ref::T = one(T)
     y::MVector{P, T} = zeros(MVector{P, T})
@@ -397,12 +398,13 @@ Returns: nothing
     va_norm = wake_speed
     
     # Calculate influence coefficients
-    for icp in eachindex(body_aero.panels)
-        panel_icp = body_aero.panels[icp]
-        ep = evaluation_point == :control_point ? panel_icp.control_point : panel_icp.aero_center
-        for jring in eachindex(body_aero.panels)
-            panel_jring = body_aero.panels[jring]
-            filaments = panel_jring.filaments
+    for jring in eachindex(body_aero.panels)
+        panel_jring = body_aero.panels[jring]
+        filaments = panel_jring.filaments
+        for icp in eachindex(body_aero.panels)
+            panel_icp = body_aero.panels[icp]
+            ep = evaluation_point == :control_point ? panel_icp.control_point :
+                 panel_icp.aero_center
             calculate_velocity_induced_single_ring_semiinfinite!(
                 velocity_induced,
                 tempvel,
@@ -421,7 +423,9 @@ Returns: nothing
                 calculate_velocity_induced_bound_2D!(U_2D, panel_jring, ep, body_aero.work_vectors)
                 velocity_induced .-= U_2D
             end
-            body_aero.AIC[:, icp, jring] .= velocity_induced
+            @inbounds for k in 1:3
+                body_aero.AIC[icp, jring, k] = velocity_induced[k]
+            end
         end
     end
     return nothing
@@ -478,25 +482,11 @@ function update_effective_angle_of_attack!(alpha_corrected,
     va_norm_array,
     va_unit_array)
 
-    # Calculate AIC matrices (keep existing optimized view)
     calculate_AIC_matrices!(body_aero, LLT, core_radius_fraction, va_norm_array, va_unit_array)
 
-    # Get dimensions from existing data
-    n_rows = size(body_aero.AIC, 2)
-    n_cols = size(body_aero.AIC, 3)
-
-    # Preallocate induced velocity array
     induced_velocity = body_aero.cache[1][va_array]
-
-    # Calculate each component with explicit loops
-    for j in 1:3  # For each x/y/z component
-        for i in 1:n_rows
-            acc = zero(eltype(induced_velocity))  # Type-stable accumulator
-            for k in 1:n_cols
-                acc += body_aero.AIC[j, i, k] * gamma[k]
-            end
-            induced_velocity[i, j] = acc
-        end
+    for k in 1:3
+        mul!(view(induced_velocity, :, k), view(body_aero.AIC, :, :, k), gamma)
     end
 
     # In-place relative velocity calculation
@@ -762,9 +752,8 @@ function calculate_results(
     cl_prescribed_va = body_aero.cache[10][alpha_dist]
     cd_prescribed_va = body_aero.cache[11][alpha_dist]
     cs_prescribed_va = body_aero.cache[12][alpha_dist]
-    panel_view_3xn = @view body_aero.AIC[:, :, 1]
-    f_body_3D = body_aero.cache[13][panel_view_3xn]
-    m_body_3D = body_aero.cache[14][panel_view_3xn]
+    f_body_3D = body_aero.cache[13][alpha_dist, (3, length(alpha_dist))]
+    m_body_3D = body_aero.cache[14][alpha_dist, (3, length(alpha_dist))]
     alpha_geometric = body_aero.cache[15][alpha_dist]
 
     fill!(f_body_3D, 0.0)

--- a/src/filament.jl
+++ b/src/filament.jl
@@ -55,24 +55,23 @@ function velocity_3D_bound_vortex!(
     r1, r2, r1Xr2, r1Xr0, r2Xr0, r1r2norm, r1_proj, r2_proj,
         r1_projXr2_proj, vel_ind_proj = work_vectors
     r0 = filament.r0
+    nr0 = filament.length
     r1 .= XVP .- filament.x1
     r2 .= XVP .- filament.x2
 
-    # Cut-off radius
-    nr0 = norm3(r0)
     epsilon = core_radius_fraction * nr0
 
-    cross3!(r1Xr2, r1, r2)
     cross3!(r1Xr0, r1, r0)
-    nr1 = norm3(r1)
-    nr2 = norm3(r2)
-    @inbounds for k in 1:3
-        r1r2norm[k] = r1[k]/nr1 - r2[k]/nr2
-    end
 
     # Check point location relative to filament
     nr1Xr0 = norm3(r1Xr0)
     if nr1Xr0 / nr0 > epsilon
+        cross3!(r1Xr2, r1, r2)
+        nr1 = norm3(r1)
+        nr2 = norm3(r2)
+        @inbounds for k in 1:3
+            r1r2norm[k] = r1[k]/nr1 - r2[k]/nr2
+        end
         nr1Xr2 = norm3(r1Xr2)
         coeff = (gamma / (4π)) / (nr1Xr2^2) * dot3(r0, r1r2norm)
         @inbounds for k in 1:3
@@ -144,7 +143,6 @@ as implemented in KiteAeroDyn".
     v_a,
     work_vectors
 )
-    r0 = work_vectors[1]
     r1 = work_vectors[2]
     r2 = work_vectors[3]
     r_perp = work_vectors[4]
@@ -153,34 +151,29 @@ as implemented in KiteAeroDyn".
     r2Xr0 = work_vectors[7]
     normr1r2 = work_vectors[8]
 
-    r0 .= filament.x2 .- filament.x1
+    r0 = filament.r0
+    nr0 = filament.length
     r1 .= XVP .- filament.x1
     r2 .= XVP .- filament.x2
 
-    # Vector perpendicular to core radius
-    nr0 = norm3(r0)
     nr0sq = nr0 * nr0
     d_r1_r0 = dot3(r1, r0)
-    @inbounds for k in 1:3
-        r_perp[k] = d_r1_r0 * r0[k] / nr0sq
-    end
 
-    # Cut-off radius
-    epsilon = sqrt(4 * ALPHA0 * NU * norm3(r_perp) / v_a)
+    # Cut-off radius. The perpendicular component has length |r1.r0|/|r0|, so the
+    # vector itself is only needed inside the core.
+    epsilon = sqrt(4 * ALPHA0 * NU * abs(d_r1_r0) / nr0 / v_a)
 
-    cross3!(r1Xr2, r1, r2)
     cross3!(r1Xr0, r1, r0)
-    cross3!(r2Xr0, r2, r0)
-
-    nr1 = norm3(r1)
-    nr2 = norm3(r2)
-    @inbounds for k in 1:3
-        normr1r2[k] = r1[k]/nr1 - r2[k]/nr2
-    end
 
     # Check point location relative to filament
     nr1Xr0 = norm3(r1Xr0)
     if nr1Xr0 / nr0 > epsilon
+        cross3!(r1Xr2, r1, r2)
+        nr1 = norm3(r1)
+        nr2 = norm3(r2)
+        @inbounds for k in 1:3
+            normr1r2[k] = r1[k]/nr1 - r2[k]/nr2
+        end
         nr1Xr2 = norm3(r1Xr2)
         coeff = (gamma / (4π)) / (nr1Xr2^2) * dot3(r0, normr1r2)
         @inbounds for k in 1:3
@@ -192,6 +185,7 @@ as implemented in KiteAeroDyn".
         # Project onto core radius — reuse r_perp, normr1r2
         r1_proj = r_perp
         r2_proj = normr1r2
+        cross3!(r2Xr0, r2, r0)
         nr2Xr0 = norm3(r2Xr0)
         d_r2_r0 = dot3(r2, r0)
         @inbounds for k in 1:3
@@ -264,22 +258,19 @@ function velocity_3D_trailing_vortex_semiinfinite!(
     work_vectors
 )
     r1 = work_vectors[1]
-    r_perp = work_vectors[2]
     r1XVf = work_vectors[3]
     GAMMA = -GAMMA * filament.filament_direction
     r1 .= XVP .- filament.x1
 
-    # Calculate core radius
+    # Core radius. `r_perp` is `(r1.Vf) Vf`, so its length is `|r1.Vf| |Vf|` and
+    # the vector itself is only needed inside the core.
     d_r1_Vf = dot3(r1, Vf)
-    @inbounds for k in 1:3
-        r_perp[k] = d_r1_Vf * Vf[k]
-    end
-    epsilon = sqrt(4 * ALPHA0 * NU * norm3(r_perp) / v_a)
+    nVf = norm3(Vf)
+    epsilon = sqrt(4 * ALPHA0 * NU * abs(d_r1_Vf) * nVf / v_a)
 
     cross3!(r1XVf, r1, Vf)
 
     nr1XVf = norm3(r1XVf)
-    nVf = norm3(Vf)
     nr1 = norm3(r1)
     if nr1XVf / nVf > epsilon
         K = GAMMA / (4π) / (nr1XVf^2) * (1 + d_r1_Vf / nr1)

--- a/src/settings.jl
+++ b/src/settings.jl
@@ -79,11 +79,11 @@ Solver configuration, used within [`VSMSettings`](@ref).
     (default `0.035`)
 - `type_initial_gamma_distribution`:
     [`ELLIPTIC`](@ref InitialGammaDistribution) or `ZEROS`
-    (default `ELLIPTIC`)
+    (default `ZEROS`)
 - `use_gamma_prev`: Reuse provided previous gamma as initial guess when
     available (default `true`)
-- `core_radius_fraction`: Vortex core radius fraction
-    (default `1e-20`)
+- `core_radius_fraction`: Bound vortex core cut-off, as a fraction of the filament
+    length, following Damiani et al. (2019) (default `0.05`)
 - `mu`: Dynamic viscosity (N*s/m^2) (default `1.81e-5`)
 - `calc_only_f_and_gamma`: Only output forces and circulation
     (default `false`)
@@ -104,9 +104,9 @@ Solver configuration, used within [`VSMSettings`](@ref).
     k4::Float64 = 0.0                       # artificial damping parameter
     is_with_artificial_viscosity::Bool = false  # Li/Gaunaa post-stall artificial viscosity
     artificial_viscosity_factor::Float64 = 0.035 # viscosity scaling coefficient k
-    type_initial_gamma_distribution::InitialGammaDistribution = ELLIPTIC # see: [InitialGammaDistribution](@ref)
+    type_initial_gamma_distribution::InitialGammaDistribution = ZEROS # see: [InitialGammaDistribution](@ref)
     use_gamma_prev::Bool = true             # if false, always reinitialize gamma from type_initial_gamma_distribution
-    core_radius_fraction::Float64 = 1e-20
+    core_radius_fraction::Float64 = 0.05
     mu::Float64 = 1.81e-5                   # dynamic viscosity [N·s/m²]
     calc_only_f_and_gamma::Bool=false       # whether to only output f and gamma
     correct_aoa::Bool=false                 # perform aoa correction

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -904,9 +904,9 @@ function gamma_loop!(
     v_normal_array           = solver.cache[10][solver.lr.gamma_new]
     v_tangential_array       = solver.cache[11][solver.lr.gamma_new]
 
-    AIC_x = @view body_aero.AIC[1, :, :]
-    AIC_y = @view body_aero.AIC[2, :, :]
-    AIC_z = @view body_aero.AIC[3, :, :]
+    AIC_x = @view body_aero.AIC[:, :, 1]
+    AIC_y = @view body_aero.AIC[:, :, 2]
+    AIC_z = @view body_aero.AIC[:, :, 3]
 
     velocity_view_x = @view induced_velocity_all[:, 1]
     velocity_view_y = @view induced_velocity_all[:, 2]

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -130,9 +130,9 @@ Main solver structure for the Vortex Step Method.See also: [solve](@ref)
     (the conservative envelope from the paper)
 
 ## Additional settings
-- `type_initial_gamma_distribution`::InitialGammaDistribution = ELLIPTIC: see: [InitialGammaDistribution](@ref)
+- `type_initial_gamma_distribution`::InitialGammaDistribution = ZEROS: see: [InitialGammaDistribution](@ref)
 - `use_gamma_prev`::Bool = true: reuse provided previous gamma as initial guess when available
-- `core_radius_fraction`::Float64 = 1e-20: 
+- `core_radius_fraction`::Float64 = 0.05:
 - mu::Float64 = 1.81e-5: Dynamic viscosity [N·s/m²]
 - `is_only_f_and_gamma_output`::Bool = false: Whether to only output f and gamma
 - `reference_point`::MVec3 = [0.0, 0.0, 0.0]: Moment reference point in body frame

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -132,7 +132,8 @@ Main solver structure for the Vortex Step Method.See also: [solve](@ref)
 ## Additional settings
 - `type_initial_gamma_distribution`::InitialGammaDistribution = ZEROS: see: [InitialGammaDistribution](@ref)
 - `use_gamma_prev`::Bool = true: reuse provided previous gamma as initial guess when available
-- `core_radius_fraction`::Float64 = 0.05:
+- `core_radius_fraction`::Float64 = 0.05: Bound vortex core cut-off, as a fraction of the
+    filament length, following Damiani et al. (2019)
 - mu::Float64 = 1.81e-5: Dynamic viscosity [N·s/m²]
 - `is_only_f_and_gamma_output`::Bool = false: Whether to only output f and gamma
 - `reference_point`::MVec3 = [0.0, 0.0, 0.0]: Moment reference point in body frame

--- a/test/body_aerodynamics/test_body_aerodynamics.jl
+++ b/test/body_aerodynamics/test_body_aerodynamics.jl
@@ -72,7 +72,7 @@ end
             va_norm_array,
             va_unit_array
         )
-        AIC_x, AIC_y, AIC_z = @views body_aero.AIC[1, :, :], body_aero.AIC[2, :, :], body_aero.AIC[3, :, :]
+        AIC_x, AIC_y, AIC_z = @views body_aero.AIC[:, :, 1], body_aero.AIC[:, :, 2], body_aero.AIC[:, :, 3]
 
         # Compare matrices
         @test isapprox(MatrixU, AIC_x, atol=1e-5)
@@ -107,7 +107,7 @@ end
             va_norm_array,
             va_unit_array
         )
-        AIC_x, AIC_y, AIC_z = body_aero.AIC[1, :, :], body_aero.AIC[2, :, :], body_aero.AIC[3, :, :]
+        AIC_x, AIC_y, AIC_z = body_aero.AIC[:, :, 1], body_aero.AIC[:, :, 2], body_aero.AIC[:, :, 3]
 
         # Compare matrices with higher precision for VSM
         @test isapprox(MatrixU, AIC_x, atol=1e-8)


### PR DESCRIPTION
Two independent changes to the `solve!` hot path. Combined effect at n=120: **8.0x** (inviscid) and **5.4x** (polars).

## 1. AIC stored component-last

`BodyAerodynamics.AIC` was `(3, n_panels, n_panels)`, so each component slice `AIC[k, :, :]` had `stride1 == 3`. That is not a valid BLAS layout, so the three `mul!` calls in `update_gamma_candidate!` silently fell back to the generic Julia matmul instead of `gemv`.

With the default `relaxation_factor = 0.03` the gamma loop runs ~247 iterations, so those three matvecs were ~80% of total `solve!` time. Isolated, the strided slice was 22-26x slower than the same matrix made contiguous.

Storing `AIC` as `(n_panels, n_panels, 3)` makes every component slice contiguous.

Also in this commit:
- AIC build loop nest swapped to `jring` outer, so the writes are unit-stride and the filament tuple hoists out of the inner loop.
- The hand-rolled triple loop in `update_effective_angle_of_attack!` becomes three `mul!` calls.
- `f_body_3D` / `m_body_3D` no longer borrow a `3 x n` slice of `AIC` as a `LazyBufferCache` shape template (there isn't one any more); they ask for the size directly.

`AIC` is an internal buffer (its only accessor, `calculate_AIC_matrices!`, is listed under private functions), so this is not a breaking change; internal code reading `AIC[k, i, j]` becomes `AIC[i, j, k]`.

## 2. Redundant work removed from the filament kernels

The three induced-velocity kernels run n^2 times per `solve!`, and each recomputed things it already had or did not need:

- `r0` and `|r0|` are `reinit!`-maintained on every `BoundFilament`, but `velocity_3D_trailing_vortex!` rebuilt both from `x1`/`x2` each call and `velocity_3D_bound_vortex!` re-normed the stored vector.
- The core-radius cutoff only needs `|r_perp|`, and `r_perp` is a projection onto `r0` (or `Vf`), so its length is `|r1.r0|/|r0|` — the vector is now built only inside the core branch that actually uses it.
- `r1 x r2`, the `r1/|r1| - r2/|r2|` difference, and `r2 x r0` were computed before the branch selecting between the regular and core-radius forms, but each is read on only one side of it.

Bit-identical: max deviation **0.0** over 28800 calls against the previous implementation.

The kernels keep their `MVector` scratch. An `SVector` rewrite is 1.14x faster again for `Float64` but **1.2-1.4x slower** for `ForwardDiff.Dual` (measured 0.84x at N=4, 0.69x at N=12), which `linearize` depends on — so it was not worth the trade.

## Numbers

| | main | after (1) | after (1)+(2) | total |
|---|---|---|---|---|
| INVISCID n=60 | 5.92 ms | 1.72 ms | 1.17 ms | **5.05x** |
| INVISCID n=120 | 26.10 ms | 4.89 ms | 3.28 ms | **7.96x** |
| POLAR_VECTORS n=60 | 6.44 ms | 2.11 ms | 1.43 ms | **4.51x** |
| POLAR_VECTORS n=120 | 21.06 ms | 6.05 ms | 3.91 ms | **5.39x** |

Allocation counts unchanged throughout (13-14).

## 3. Docstring fixes

The `Solver` docstring listed `type_initial_gamma_distribution` as `ELLIPTIC` (it is `ZEROS`) and `core_radius_fraction` as `1e-20` (it is `0.05`).

## Testing

```
Induction Matrix Creation                      6/6      <- AIC vs reference matrices, atol=1e-8
Calculate results against output results      26/26
Wing Geometry Creation                      4803/4803
set_va! (3 testsets)                          23/23
Linearize Jacobian validation                 30/30     <- ForwardDiff/Dual path
Solver Constructor                             3/3
NONLIN solve! re-runs across calls             2/2
calc_forces! is zero-alloc                     1/1
Spanwise Laplacian tip closures                5/5
apply_artificial_viscosity!                    5/5
solve! artificial viscosity                    2/2
Panel Tests                                   24/24
BoundFilament Tests                          105/105
SemiInfiniteFilament Tests                    58/58
frozen_wake! Tests                             3/3
```

Zero failures, run after both changes. The geometry/IO groups were left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 3. `SolverSettings` defaults aligned with `Solver`

`Solver` and `SolverSettings` disagreed on two defaults, and `Solver(settings)`
passed the divergence straight through, so the same nominal default meant
different things depending on how you configured the solve:

| | `Solver` | `SolverSettings` (before) |
|---|---|---|
| `core_radius_fraction` | `0.05` | `1e-20` |
| `type_initial_gamma_distribution` | `ZEROS` | `ELLIPTIC` |

`SolverSettings` now uses `0.05` / `ZEROS`. `0.05` is the upstream
[`awegroup/Vortex-Step-Method`](https://github.com/awegroup/Vortex-Step-Method)
default, attributed there to Damiani et al. (2019), *A Vortex Step Method for
Nonlinear Airfoil Polar Data as Implemented in KiteAeroDyn*; upstream likewise
defaults `gamma_initial_distribution_type` to `"zero"`.

**This moves no numbers.** At `1e-20` the Biot-Savart singularity guard simply
never engaged. The branch fires when `perp_dist/‖r0‖ < core_radius_fraction`,
and for a wing that ratio is `0.5·n/AR`, so triggering needs `n < 0.1·AR` —
under 2 panels on an AR-20 wing. Verified on an arc wing (60° half-arc, R=8),
where bound filaments are genuinely non-collinear: `dCL = 0.0` and
`max‖Δγ‖/max‖γ‖ = 0.0` at α = 5°/10°/20°, n = 40/80. The fix matters for
degenerate geometry (near-touching panels, deformed or multi-body layouts), not
for coefficient accuracy. Every settings file in `data/` sets both keys
explicitly, so none of them change.

Also documented `core_radius_fraction` in both docstrings (it had an empty
description in `Solver`) and corrected three YAML comments that called it a
fraction of chord — it is a fraction of filament length, i.e. panel width.

### Tests

Full suite green on this branch: **6131 pass, 0 fail**, 10m09.7s (the single
`broken` is a pre-existing `@test_broken` in Kite Geometry Tests).


---

## 4. CI: keep test-env precompilation lazy on macOS and Windows

Unrelated to the changes above, but it was blocking this PR and affects `main`
equally, so it is fixed here rather than split out.

macOS-aarch64 and Windows-x64 began failing on every branch with:

```
GLFWError (FORMAT_UNAVAILABLE): NSGL: Failed to find a suitable pixel format
Failed to precompile GLMakie → MakieControlPlots → VortexStepMethodMakieExt
```

Isolated by diffing the last green `main` run against a failing one — only the
Julia patch version differed:

| | Aug 13 (pass) | Aug 17 (fail) |
|---|---|---|
| Julia | **1.12.6** | **1.12.7** |
| Runner image | macos-26-arm64 20260728.0273.1 | identical |
| GLMakie / GLFW / GLFW_jll | 0.13.13 / 3.4.6 / 3.4.1+1 | identical |

`test/runtests.jl` already skips plotting off Linux, and the Aug 13 macOS log
prints `Skipping plotting tests on Darwin: GLMakie needs a display.` and passes.
But that guard runs at *test* time; 1.12.7 precompiles the whole test
environment first, so `MakieControlPlots` (top-level `using GLMakie`) loads and
fails before the guard is reached. `CI.yml` only provisions xvfb on Linux.

Fix — keep precompilation lazy where there is no display, so the existing guard
is reached before GLMakie is ever loaded:

```yaml
JULIA_PKG_PRECOMPILE_AUTO: ${{ runner.os == 'Linux' && '1' || '0' }}
```

macOS now reports `6060 pass, 1 broken` in 4m41s (was 15m43s failing). The
71-test gap versus Linux's 6131 is exactly the Linux-only plotting testsets
(58 Plotting + 13 Airfoil skin), so nothing is silently skipped.

Trade-off worth knowing: those two jobs no longer get an up-front precompile of
the test environment, so a genuine precompile error in a non-plotting test dep
would surface as a load error mid-suite rather than cleanly before it starts.
Fixing it at the source instead would mean moving `MakieControlPlots` out of
`test/Project.toml` into a Linux-only job with its own environment.

**All 9 checks green.**

