### PR TITLE
Take the billow axis from the section pair, not a global projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Billowing now takes its rotation axis from the section pair itself instead of
+  projecting the leading-edge span vector on `spanwise_direction`. Sections run
+  `+y` to `-y`, so the pair already fixes the sign. The projection was decided by
+  3 % of the vector on a C-shaped kite's tip panels — 11 mm of span between the
+  outermost sections — so a deforming tip could flip that one panel's billow.
+
 ## VortexStepMethod v4.1.1 2026-08-19
 
 ### Fixed

--- a/src/wing_geometry.jl
+++ b/src/wing_geometry.jl
@@ -1535,18 +1535,14 @@ function refine_mesh_by_splitting_provided_sections!(
             # Apply billowing by rotating chords around LE.
             if billowing_percentage > 0 && idx > start_idx
                 s_l = sections[li]; s_r = sections[li + 1]
-                if dot(s_l.LE_point - s_r.LE_point, wing.spanwise_direction) >= 0
-                    le_neg, le_pos = s_r.LE_point, s_l.LE_point
-                else
-                    le_neg, le_pos = s_l.LE_point, s_r.LE_point
-                end
-                diff_vec = le_pos - le_neg
+                # Sections run +y to -y, so the pair fixes the axis sign on its own.
+                diff_vec = s_l.LE_point - s_r.LE_point
                 span_len = norm(diff_vec)
                 y_hat = diff_vec / span_len
                 apply_billowing_to_pair!(
                     wing.refined_sections,
                     start_idx, idx - 1,
-                    y_hat, span_len, le_neg,
+                    y_hat, span_len, s_r.LE_point,
                     s_l.TE_point, s_r.TE_point,
                     billowing_percentage)
             end


### PR DESCRIPTION
## Problem

Billowing rotates each refined section's trailing edge about the leading-edge
span vector of the surrounding rib pair. The *sign* of that vector decides
whether the panel billows up or down, and it was chosen by projecting on
`wing.spanwise_direction`:

```julia
if dot(s_l.LE_point - s_r.LE_point, wing.spanwise_direction) >= 0
    le_neg, le_pos = s_r.LE_point, s_l.LE_point
else
    le_neg, le_pos = s_l.LE_point, s_r.LE_point
end
```

That test is well-conditioned only where the span vector is actually spanwise.
On a C-shaped kite the tip panels are nearly vertical, so their leading-edge
span vector is mostly x and z. Measured on the V3 kite's 37-section aero
geometry (`spanwise_direction = [0, 1, 0]`, LE y running +4.167 → −4.167):

| pair | \|y_hat · spanwise_direction\| |
|---|---|
| 1 (tip) | **0.033** |
| 2 | 0.071 |
| 3 | 0.115 |
| 4–33 | 0.23 – 1.00 |
| 34 | 0.115 |
| 35 | 0.071 |
| 36 (tip) | **0.033** |

The outermost pair is separated by 11 mm of span. Since `refine!` re-runs on
the deformed sections each aero update, a flexing tip only has to move two
adjacent leading-edge nodes 11 mm relative to each other in y for that one
panel's billow to invert while its neighbours keep theirs.

## Fix

Sections are guaranteed to run `+y` to `-y` (`normalize_span_order!` /
`refine!`'s `sort_sections`), so the pair itself fixes the axis sign with no
projection and no degeneracy:

```julia
diff_vec = s_l.LE_point - s_r.LE_point
```

`spanwise_direction` still sets the wing's overall handedness once, where it is
well-conditioned; it no longer decides each panel individually.

## Effect

On a geometry whose tips are not near-vertical the two rules agree, so the
refined mesh is unchanged. On the V3 geometry above the old test also happened
to agree on all 36 pairs in the *undeformed* mesh — the change is a no-op there
— but it removes the 3 % margin the tip panels were relying on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)