### PR TITLE
Take the panel normal from the quarter-chord step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- `panel_axes` builds the panel normal from the quarter-chord step rather than
+  the leading-edge step. `z_airf` was `cross(x_airf, le_1 - le_2)` while the
+  bound vortex, `width` and `y_airf` all come from `panel_span_vector`, so on a
+  panel whose two sections have differently-directed chords the normal was not
+  square to the vortex the loads are built from. `alpha` is measured against
+  that normal, so every panel coefficient inherited the error. The frame now
+  closes as `z_airf = x_airf × y_airf`, which is what the `Panel` field
+  docstring already described.
+
+  Taper alone never triggered it: `(le_1 - le_2) - span_vec` is a quarter of
+  `chord_vec_2 - chord_vec_1`, which is purely chordwise when the two chords are
+  parallel, and `cross(x_airf, ·)` annihilates it. Twist, sweep and dihedral do
+  trigger it — 0.84° of twist on the `:rectangular` reference wing, and
+  5.6–13.8° on the raked outboard bay of a leading-edge-inflatable kite.
+
 ## VortexStepMethod v4.3.1 2026-09-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,11 @@
 
 ### Fixed
 
-- `panel_axes` builds the panel normal from the quarter-chord step rather than
-  the leading-edge step. `z_airf` was `cross(x_airf, le_1 - le_2)` while the
-  bound vortex, `width` and `y_airf` all come from `panel_span_vector`, so on a
-  panel whose two sections have differently-directed chords the normal was not
-  square to the vortex the loads are built from. `alpha` is measured against
-  that normal, so every panel coefficient inherited the error. The frame now
-  closes as `z_airf = x_airf × y_airf`, which is what the `Panel` field
-  docstring already described.
-
-  Taper alone never triggered it: `(le_1 - le_2) - span_vec` is a quarter of
-  `chord_vec_2 - chord_vec_1`, which is purely chordwise when the two chords are
-  parallel, and `cross(x_airf, ·)` annihilates it. Twist, sweep and dihedral do
-  trigger it — 0.84° of twist on the `:rectangular` reference wing, and
-  5.6–13.8° on the raked outboard bay of a leading-edge-inflatable kite.
+- `panel_axes` takes the panel normal from the quarter-chord step, so the frame
+  closes as `z_airf = x_airf × y_airf` and `z_airf` is square to the bound
+  vortex. `alpha` is measured against that normal, so `cl`, `cd` and `cm` were
+  wrong on panels whose two sections have differently-directed chords — twist,
+  sweep or dihedral, not taper alone.
 
 ## VortexStepMethod v4.3.1 2026-09-01
 

--- a/src/panel_aerodynamics.jl
+++ b/src/panel_aerodynamics.jl
@@ -49,6 +49,11 @@ end
 Airfoil frame and size of the panel between two sections, as
 `(; x_airf, y_airf, z_airf, chord, width)`.
 
+`x_airf` is chordwise and `y_airf` runs along the quarter-chord line the bound
+vortex sits on, so `z_airf` is their cross product. The first two are not orthogonal
+on a swept panel; taking the normal from the quarter-chord step rather than the
+leading-edge step is what keeps it square to the vortex the loads are built from.
+
 `chord_weight` ([`panel_chord_weight`](@ref)) enters as an offset from the
 midpoint rather than as `w·p₁ + (1-w)·p₂`: the two are equal, but the offset form
 leaves a constant term to fold, which a symbolic consumer builds several times
@@ -63,7 +68,7 @@ on section ordering.
     width = smooth_norm(span_vec)
     x_airf = chord_vec ./ smooth_norm(chord_vec)
     y_airf = orient .* (span_vec ./ width)
-    z_cross = cross(x_airf, le_1 .- le_2)
+    z_cross = cross(x_airf, span_vec)
     z_airf = orient .* (z_cross ./ smooth_norm(z_cross))
     return (; x_airf, y_airf, z_airf,
             chord=panel_chord(le_1, te_1, le_2, te_2), width)

--- a/src/panel_aerodynamics.jl
+++ b/src/panel_aerodynamics.jl
@@ -47,18 +47,11 @@ end
     panel_axes(le_1, te_1, le_2, te_2, chord_weight=0.5, orient=1)
 
 Airfoil frame and size of the panel between two sections, as
-`(; x_airf, y_airf, z_airf, chord, width)`.
-
-`x_airf` is chordwise and `y_airf` runs along the quarter-chord line the bound
-vortex sits on, so `z_airf` is their cross product. The first two are not orthogonal
-on a swept panel; taking the normal from the quarter-chord step rather than the
-leading-edge step is what keeps it square to the vortex the loads are built from.
-
-`chord_weight` ([`panel_chord_weight`](@ref)) enters as an offset from the
-midpoint rather than as `w·p₁ + (1-w)·p₂`: the two are equal, but the offset form
-leaves a constant term to fold, which a symbolic consumer builds several times
-faster. `orient` is `±1`, flipping `y_airf`/`z_airf` so the frame does not depend
-on section ordering.
+`(; x_airf, y_airf, z_airf, chord, width)`. `x_airf` is chordwise, `y_airf` runs
+along the quarter-chord line the bound vortex sits on — not square to `x_airf` on
+a swept panel — and `z_airf` is `x_airf × y_airf` normalised. `chord_weight`
+([`panel_chord_weight`](@ref)) is section 1's share of the chord-direction blend;
+`orient` is `±1` and flips `y_airf` and `z_airf` together.
 """
 @inline function panel_axes(le_1, te_1, le_2, te_2, chord_weight=0.5, orient=1)
     lean = chord_weight - 0.5

--- a/test/panel/test_panel.jl
+++ b/test/panel/test_panel.jl
@@ -1,4 +1,5 @@
 using VortexStepMethod: Panel, Section, calculate_relative_alpha_and_relative_velocity, calculate_cl, calculate_cd_cm, reinit!, INVISCID, POLAR_VECTORS, MVec3
+using VortexStepMethod: panel_axes, panel_span_vector
 using Interpolations: linear_interpolation, Line
 using LinearAlgebra
 using Test
@@ -166,5 +167,41 @@ end
             @test isapprox(cd, expected_cd, rtol=1e-5)
             @test isapprox(cm, expected_cm, rtol=1e-5)
         end
+    end
+end
+
+@testset "Panel frame on a swept, twisted panel" begin
+    twist = deg2rad(35)
+    le_1 = [0.0, 0.0, 0.0]
+    te_1 = [2.0, 0.0, 0.0]
+    le_2 = [1.2, 1.0, 0.0]
+    te_2 = le_2 .+ 1.4 .* [cos(twist), 0.0, -sin(twist)]
+    axes = panel_axes(le_1, te_1, le_2, te_2)
+    span_vec = panel_span_vector(le_1, te_1, le_2, te_2)
+
+    leading_edge_normal = cross(axes.x_airf, le_1 .- le_2)
+    leading_edge_normal ./= norm(leading_edge_normal)
+    separation = rad2deg(acos(clamp(abs(dot(leading_edge_normal, axes.z_airf)), -1, 1)))
+
+    @testset "the geometry discriminates the two definitions" begin
+        @test separation > 5
+    end
+
+    @testset "the normal is square to the bound vortex and the chord" begin
+        @test abs(dot(axes.z_airf, span_vec)) < 1e-12
+        @test abs(dot(axes.z_airf, axes.y_airf)) < 1e-12
+        @test abs(dot(axes.z_airf, axes.x_airf)) < 1e-12
+    end
+
+    @testset "the frame closes as z = x cross y" begin
+        closure = cross(axes.x_airf, axes.y_airf)
+        @test isapprox(closure ./ norm(closure), axes.z_airf; atol=1e-12)
+    end
+
+    @testset "orient flips y and z together" begin
+        flipped = panel_axes(le_1, te_1, le_2, te_2, 0.5, -1)
+        @test isapprox(flipped.y_airf, -axes.y_airf; atol=1e-12)
+        @test isapprox(flipped.z_airf, -axes.z_airf; atol=1e-12)
+        @test isapprox(flipped.x_airf, axes.x_airf; atol=1e-12)
     end
 end

--- a/test/thesis_oriol_cayon.jl
+++ b/test/thesis_oriol_cayon.jl
@@ -194,11 +194,11 @@ function create_geometry_general(coordinates, Uinf, N, ring_geo, model)
         )
         push!(filaments, bound)
 
-        x_airf = cross(VSMpoint - LLpoint, section["p2"] - section["p1"])
+        z_airf = bound["x2"] - bound["x1"]
+        x_airf = cross(VSMpoint - LLpoint, z_airf)
         x_airf = x_airf / norm(x_airf)
         y_airf = VSMpoint - LLpoint
         y_airf = y_airf / norm(y_airf)
-        z_airf = bound["x2"] - bound["x1"]
         z_airf = z_airf / norm(z_airf)
         airf_coord = hcat(x_airf, y_airf, z_airf)
 


### PR DESCRIPTION
Fixes #272.

`panel_axes` built the panel normal from the leading-edge step:

```julia
span_vec = panel_span_vector(le_1, te_1, le_2, te_2)   # quarter-chord step
y_airf   = orient .* (span_vec ./ width)
z_cross  = cross(x_airf, le_1 .- le_2)                 # leading-edge step
```

The bound vortex, `width` and `y_airf` all come from the quarter-chord step, so
`z_airf` was the odd one out. On a panel whose two sections have
differently-directed chords the normal is then not square to the vortex the loads
are built from, and since `alpha = atan(v·z_airf, v·x_airf)` feeds every polar
lookup, the error propagates into `cl`, `cd` and `cm` for that panel.

One character of the fix: `cross(x_airf, span_vec)`. The frame now closes as
`z_airf = x_airf × y_airf`, which is what the `Panel` field docstring
(`src/panel.jl:28`) has always claimed.

### Why it went unnoticed

Taper alone cannot trigger it. `(le_1 - le_2) - span_vec` equals
`¼(chord_vec_2 - chord_vec_1)`, which is purely chordwise when the two chords are
parallel, and `cross(x_airf, ·)` annihilates the chordwise part exactly. It takes
twist, sweep or dihedral — something that changes the chord *direction* between
the two sections — for the normals to separate at all.

The reference wings barely do that:

| reference wing | angle(LE step, QC step) | normal changes? |
|---|---|---|
| `:rectangular` | 0.84°, from its ±0.5 rad twist | yes |
| `:curved` | 0.00° — LE and TE share `(y, z)` | no |
| `:elliptical` | 34.01° | no — planar, so the normal is `±ẑ` regardless |

The elliptical wing separates the two steps by 34° and still cannot see the
difference. Nothing in the suite combines sweep with a changing chord direction,
which is the only regime where the choice matters.

### Changes to the reference oracle

`test/thesis_oriol_cayon.jl` makes the same mix (its `x_airf` is the normal, its
`z_airf` the spanwise axis):

```julia
x_airf = cross(VSMpoint - LLpoint, section["p2"] - section["p1"])  # LE step
z_airf = bound["x2"] - bound["x1"]                                 # QC step
```

so the inconsistency is inherited from the original formulation rather than
introduced by the port, and the oracle has to move with the code or it pins the
old convention. It now takes the normal from the bound filament it already builds
— a two-line change that reuses `bound["x2"] - bound["x1"]` instead of recomputing
from the leading edges.

**This is the part worth reviewing carefully**, since it is the test changing to
match the code. It is defensible here because the oracle's own spanwise axis is
already the quarter-chord step, so the change makes it self-consistent rather than
merely agreeing with us. Without it, 156 assertions fail (2 models × 39 panels × 2
asserts, all on `:rectangular`) at ~0.25° — real but small.

To avoid leaning on the oracle for the thing being fixed, the new test in
`test/panel/test_panel.jl` states the invariant directly on a swept, twisted panel
where the two definitions are **13.7° apart**: the normal is square to the bound
vortex and to the chord, the frame closes as `z = x × y`, and `orient` flips `y`
and `z` together. It carries a guard asserting the geometry actually discriminates
the two definitions, so it cannot silently decay into a test of nothing.

### Measured effect

SK100 leading-edge-inflatable kite, 44 panels, outermost rib bay raked 58–68°,
where the old and new normals are 5.6–13.8° apart. Coupled beam + VSM flight,
identical settle (1200/1200 steps):

| `z_cross` from | steps flown before the VSM solve stops converging |
|---|---|
| `le_1 - le_2` | 122 |
| `span_vec` | 189 |

Same failure mode either way — a tip-stall divergence — so the frame error
aggravates it rather than causing it, but it is worth ~55% more flight time here.

### Deliberately not included

Orthogonalising `y_airf` against `x_airf`. It measures *better* on the kite (217
steps), but that metric records how long a stall divergence is deferred, not
accuracy, and both of `y_airf`'s uses argue for keeping the raw quarter-chord
direction: `dir_lift` is Kutta–Joukowski (`F = ρ v × Γ`, `Γ` along the bound
vortex), and `q_dyn = ½ρ|v × y|²` is the simple-sweep normal-to-quarter-chord
component. Settling that needs a swept, tapered validation case with a known
answer, which does not exist in the suite yet. Left open on #272.

### Downstream

SymbolicAWEModels.jl rebuilds this same expression symbolically in
`build_panel_force_eqs` and again in `wagner_reference_frame`. Those need the
matching change or its symbolic force assembly disagrees with this solver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
