### PR TITLE
Release v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## VortexStepMethod v4.4.0 2026-09-07
 
 ### Added
 
@@ -23,6 +23,22 @@
   different transition settings than it was tabulated at.
 - Reynolds is stated once: `reynolds(set, wing)` takes the air from
   `solver_settings` and the reference speed and chord from `airfoil:`.
+
+### Changed
+
+- `shrink_wrap` traces the rolling ball exactly — pivoting it around the cloud
+  and offsetting the polygon through the points it touches (`pivot_contour`) —
+  instead of thresholding and marching-squares-tracing a distance field, so
+  there is no grid resolution left to set. `ShrinkWrap`'s `cell_size` is
+  accordingly named `min_clearance`, still accepted under the old name, and
+  floors `clearance` only
+  for an open single-membrane cloud; a closed loop keeps its true `clearance`, so
+  `clearance=0` hugs the input and leaves its sharp trailing edge sharp. The wrap
+  sits at exactly `clearance` from the cloud instead of a cell over it, so a V3
+  canopy's aft strip comes out `2 * clearance` thick where the grid gave
+  `3.5 * cell_size`. `min_concave_radius` stops costing anything,
+  having padded the grid in both directions before: one V3 slice at radius 0.4
+  drops from 173 ms to 10 ms, and at the default radius from 15 ms to 3 ms.
 
 ## VortexStepMethod v4.3.1 2026-09-01
 
@@ -327,19 +343,6 @@
   `reduce(vcat, …)` over a generator, which was quadratic in the row count: ~21×
   faster on a 16 MB surface table (2.49 s → 0.12 s), benefiting every existing
   dataset.
-- `shrink_wrap` traces the rolling ball exactly — pivoting it around the cloud
-  and offsetting the polygon through the points it touches (`pivot_contour`) —
-  instead of thresholding and marching-squares-tracing a distance field, so
-  there is no grid resolution left to set. `ShrinkWrap`'s `cell_size` is
-  accordingly named `min_clearance`, still accepted under the old name, and
-  floors `clearance` only
-  for an open single-membrane cloud; a closed loop keeps its true `clearance`, so
-  `clearance=0` hugs the input and leaves its sharp trailing edge sharp. The wrap
-  sits at exactly `clearance` from the cloud instead of a cell over it, so a V3
-  canopy's aft strip comes out `2 * clearance` thick where the grid gave
-  `3.5 * cell_size`. `min_concave_radius` stops costing anything,
-  having padded the grid in both directions before: one V3 slice at radius 0.4
-  drops from 173 ms to 10 ms, and at the default radius from 15 ms to 3 ms.
 - `is_show=true` draws into a window named after the plot title instead of into
   whichever window the backend last used, so a script showing several plots gets
   one window each and re-running it redraws them in place. `show_plot` takes the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## VortexStepMethod v4.4.0 2026-09-07
+## VortexStepMethod v5.0.0 2026-09-07
 
 ### Added
 
@@ -26,19 +26,19 @@
 
 ### Changed
 
-- `shrink_wrap` traces the rolling ball exactly — pivoting it around the cloud
-  and offsetting the polygon through the points it touches (`pivot_contour`) —
-  instead of thresholding and marching-squares-tracing a distance field, so
-  there is no grid resolution left to set. `ShrinkWrap`'s `cell_size` is
-  accordingly named `min_clearance`, still accepted under the old name, and
-  floors `clearance` only
-  for an open single-membrane cloud; a closed loop keeps its true `clearance`, so
-  `clearance=0` hugs the input and leaves its sharp trailing edge sharp. The wrap
-  sits at exactly `clearance` from the cloud instead of a cell over it, so a V3
-  canopy's aft strip comes out `2 * clearance` thick where the grid gave
-  `3.5 * cell_size`. `min_concave_radius` stops costing anything,
-  having padded the grid in both directions before: one V3 slice at radius 0.4
-  drops from 173 ms to 10 ms, and at the default radius from 15 ms to 3 ms.
+- BREAKING: `shrink_wrap` traces the rolling ball exactly — pivoting it around
+  the cloud and offsetting the polygon through the points it touches
+  (`pivot_contour`) — instead of thresholding and marching-squares-tracing a
+  distance field, so there is no grid resolution left to set. `ShrinkWrap`'s
+  `cell_size` is accordingly named `min_clearance`, still accepted under the old
+  name, and floors `clearance` only for an open single-membrane cloud; a closed
+  loop keeps its true `clearance`, so `clearance=0` hugs the input and leaves
+  its sharp trailing edge sharp. The wrap sits at exactly `clearance` from the
+  cloud instead of a cell over it, so a V3 canopy's aft strip comes out
+  `2 * clearance` thick where the grid gave `3.5 * cell_size`.
+  `min_concave_radius` stops costing anything, having padded the grid in both
+  directions before: one V3 slice at radius 0.4 drops from 173 ms to 10 ms, and
+  at the default radius from 15 ms to 3 ms.
 
 ## VortexStepMethod v4.3.1 2026-09-01
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "VortexStepMethod"
 uuid = "ed3cd733-9f0f-46a9-93e0-89b8d4998dd9"
 authors = ["1-Bart-1 <bart@vandelint.net>", "Oriol Cayon and contributors"]
-version = "4.4.0"
+version = "5.0.0"
 
 [workspace]
 projects = ["examples", "docs", "test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "VortexStepMethod"
 uuid = "ed3cd733-9f0f-46a9-93e0-89b8d4998dd9"
 authors = ["1-Bart-1 <bart@vandelint.net>", "Oriol Cayon and contributors"]
-version = "4.3.1"
+version = "4.4.0"
 
 [workspace]
 projects = ["examples", "docs", "test"]


### PR DESCRIPTION
### TL;DR

Sets `Project.toml` to 5.0.0 and names the shipping changelog section
`## VortexStepMethod v5.0.0 2026-09-07`. That section also gains #262's entry,
which sat under the already-released v4.1.0 heading and would otherwise have
been dropped from the release notes; it is prefixed `BREAKING:`.

### Verification

- [x] `bin/release`'s own version guard and notes-extraction stanzas, run
      against the working tree: version guard yields `v5.0.0`, matching
      `Project.toml`; notes come out as `### Added` (5 bullets) plus
      `### Changed` (1 bullet, `BREAKING:`). On `main` at `0a8f046` the guard
      yields `v4.3.1` — see the surprise below.
- [x] `git diff --word-diff` over `CHANGELOG.md` for the latest commit shows
      exactly three tokens: `-v4.4.0`, `+v5.0.0`, `+BREAKING:`. The 13-line
      bullet is rewrapped to 80 columns, and the word diff proves no wording
      moved with it.
- [x] The #262 block this PR moved up is byte-identical to `main`'s (`diff`,
      exit 0) apart from that rewrap.
- [x] `main` green: run 34126474537 on `0a8f046`, all 7 jobs including
      Documentation. Rebased on `main`, which has not moved.
- No tests run and no local CI mirror: `git diff origin/main -- src test docs
  README.md` is empty, so the tree under test is `main`'s. Nothing in `src/`,
  `test/` or `docs/` reads `Project.toml`'s version or `CHANGELOG.md`
  (grepped). `deno fmt` not run — deno is not on the box and no workflow
  formats markdown; the changed lines are ≤ 80 columns. REUSE lint n/a.

### Reviewer's guide

- Two files, and `Project.toml` is the whole of one of them.
- In `CHANGELOG.md`, read the header and the first three words of the
  `### Changed` bullet. `git show --color-moved=zebra 74c72cf` greys the moved
  block; `git show --word-diff 5612d24` is the reclassification on its own.
- Risk: the header says `2026-09-07`; merging on a later day wants that changed.

### Decisions

- **v5.0.0, not the v4.4.0 asked for in #276.** Bart: "The shrinkwrap being
  continuous makes this a breaking release. It's results are different than the
  gridded approach from before." This repo bumps the major for that — its only
  other `BREAKING` entries sit under `v4.0.0` — so a breaking release off
  `v4.3.1` is `v5.0.0`. Say the word before merging if you meant to keep the
  number and only flag the notes.
- The `BREAKING:` prefix goes on #262's entry, which is where the break is: the
  wrap is a different shape (a V3 canopy's aft strip comes out `2 * clearance`
  thick where the grid gave `3.5 * cell_size`), and `ShrinkWrap`'s `cell_size`
  field is renamed `min_clearance` — construction still takes `cell_size=`
  (`shrink_wrap.jl:42-44`), but `sw.cell_size` now errors. AGENTS.md §4 spells
  the prefix `BREAKING:`; the v4.0.0 entries use `BREAKING - `. Followed the
  rules file.
- **Two PRs have merged since v4.3.1, not one.** #276 said #271 alone and asked
  me to check. #262 is in `v4.3.1..main` too, and `pivot_contour` /
  `min_clearance` exist on `main` but not at `v4.3.1`, so it has shipped in no
  release. `536a67f` returned its entry to the v4.1.0 section because an earlier
  attempt at that rewrite lived there before `2030908` pulled it out pre-v4.1.0.
  Moving it is the same idea as the rest of this PR, and §4 Releasing step 1
  wants it before `bin/release` runs — so it is here, not in a second PR the
  release would also wait for.
- #273 is still open (checked again just now), so it is not in this release and
  its `### Fixed` entry stays on its own branch.
- Surprise, filed as #280: `bin/release`'s version guard scans every `## `
  header rather than the top one, so with `## Unreleased` on top it matched
  `v4.3.1` and would have re-registered an existing tag under the unreleased
  notes. **`agent release` must not run until this PR merges.**
- Also filed: #278 (no settings-file reference page, and the README never
  mentions settings files — predates this release, so it did not hold it up)
  and #279 (`fail-fast: false` in `CI.yml`).

### Scope

+18 / -15 across 2 files; the bulk is #262's entry moved into the shipping
section. Branch is still named `agent/276-release-v4-4-0`; renaming it would
rewrite a pushed branch, so it stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TgCWZVmVByLWrA5sStHry

Closes #276 · task `VortexStepMethod.jl-276`
