### PR TITLE
Let a caller ask solve! to throw on a failed solve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- `solve!(...; throw_on_fail=true)` throws a `SolveFailure` when the circulation
+  loop missed the solver's tolerances or the coefficients it assembled are not
+  finite — `ForwardDiff.Dual` partials included — so a caller that cannot use a
+  failed solve gets an exception rather than a `VSMSolution` it has to inspect.
+  The default is off: a post-stall solve that misses the tolerances still returns
+  its `solver_status == FAILURE` solution.
+
 ## VortexStepMethod v5.0.0 2026-09-07
 
 ### Added

--- a/docs/src/private_functions.md
+++ b/docs/src/private_functions.md
@@ -19,6 +19,7 @@ local_lift_slope!
 apply_artificial_viscosity!
 frozen_wake!
 calc_forces!
+finite_full
 calculate_cl
 calculate_cd
 calculate_cm

--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -50,4 +50,5 @@ BodyAerodynamics
 ```@docs
 Solver
 VSMSolution
+SolveFailure
 ```

--- a/src/VortexStepMethod.jl
+++ b/src/VortexStepMethod.jl
@@ -32,6 +32,7 @@ export slice_args, preview_args
 export ObjWing, Section, Wing, refine!, reinit!
 export BodyAerodynamics
 export Solver, VSMSolution, linearize, solve, solve!, solve_base!, calc_forces!
+export SolveFailure
 export calculate_results
 export add_section!, set_va!, section_pitch_rate
 export calculate_projected_area, calculate_span

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -224,8 +224,31 @@ function Solver(body_aero, settings::VSMSettings)
 end
 
 """
+    SolveFailure(msg)
+
+Thrown by `solve!(...; throw_on_fail=true)` when the circulation loop missed the
+solver's tolerances, or when the coefficients it assembled are not finite.
+"""
+struct SolveFailure <: Exception
+    msg::String
+end
+
+Base.showerror(io::IO, failure::SolveFailure) = print(io, failure.msg)
+
+"""
+    finite_full(x) -> Bool
+
+`true` if `x` is finite. A `ForwardDiff.Dual` needs every partial finite too, so
+a non-finite *derivative* of a solve is caught as well as a non-finite value.
+"""
+finite_full(x::Real) = isfinite(x)
+finite_full(x::ForwardDiff.Dual) =
+    isfinite(ForwardDiff.value(x)) && all(isfinite, ForwardDiff.partials(x))
+
+"""
     solve!(solver::Solver, body_aero::BodyAerodynamics, gamma_distribution=solver.sol.gamma_distribution; 
-          log=false, reference_point=solver.reference_point, moment_frac=0.1)
+          log=false, reference_point=solver.reference_point, moment_frac=0.1,
+          throw_on_fail=false)
 
 Main solving routine for the aerodynamic model. Reference point is in the kite body (KB) frame.
 This version is modifying the `solver.sol` struct and is faster than the `solve` function which returns
@@ -240,12 +263,16 @@ a dictionary.
 - log=false: If true, print the number of iterations and other info.
 - reference_point=solver.reference_point
 - moment_frac=0.1: X-coordinate of normalized panel around which the moment distribution should be calculated.
+- throw_on_fail=false: If true, throw a [`SolveFailure`](@ref) instead of returning a
+  solution that missed the solver's tolerances or carries a non-finite coefficient.
 
 # Returns
-The solution of type [`VSMSolution`](@ref)
+The solution of type [`VSMSolution`](@ref), whose `solver_status` is `FAILURE` when the
+circulation loop missed the solver's tolerances.
 """
 function solve!(solver::Solver{P, U, T}, body_aero::BodyAerodynamics, gamma_distribution=solver.sol.gamma_distribution;
-        log=false, reference_point=solver.reference_point, moment_frac=0.1) where {P, U, T}
+        log=false, reference_point=solver.reference_point, moment_frac=0.1,
+        throw_on_fail=false) where {P, U, T}
 
     # calculate intermediate result
     solve_base!(solver, body_aero, gamma_distribution; log)
@@ -256,7 +283,13 @@ function solve!(solver::Solver{P, U, T}, body_aero::BodyAerodynamics, gamma_dist
         solver.sol.gamma_distribution = gamma_new
     end
 
-    return calc_forces!(solver, body_aero; reference_point, moment_frac)
+    sol = calc_forces!(solver, body_aero; reference_point, moment_frac)
+    throw_on_fail || return sol
+    solver.lr.converged || throw(SolveFailure(
+        "VSM solve did not converge in $(solver.max_iterations) iterations."))
+    all(finite_full, sol.force_coeffs) && all(finite_full, sol.moment_coeffs) ||
+        throw(SolveFailure("VSM solve assembled non-finite coefficients."))
+    return sol
 end
 
 """

--- a/test/solver/test_solver.jl
+++ b/test/solver/test_solver.jl
@@ -1,5 +1,6 @@
 using VortexStepMethod
 using VortexStepMethod.AirfoilAero: lei_poly_coeffs
+using ForwardDiff
 using LinearAlgebra
 using Test
 if !@isdefined(test_data_path)
@@ -209,4 +210,16 @@ end
     @test sol.solver_status == FAILURE
 
     @test_throws SolveFailure solve!(solver, body_aero; throw_on_fail=true)
+    @test_throws "did not converge in 1 iterations" solve!(solver, body_aero;
+        throw_on_fail=true)
+
+    converged = Solver(body_aero; solver_type=LOOP, aerodynamic_model_type=VSM)
+    @test solve!(converged, body_aero; throw_on_fail=true) isa VSMSolution
+end
+
+@testset "finite_full sees a Dual's partials, not just its value" begin
+    @test VortexStepMethod.finite_full(1.0)
+    @test !VortexStepMethod.finite_full(NaN)
+    @test VortexStepMethod.finite_full(ForwardDiff.Dual(1.0, 2.0))
+    @test !VortexStepMethod.finite_full(ForwardDiff.Dual(1.0, Inf))
 end

--- a/test/solver/test_solver.jl
+++ b/test/solver/test_solver.jl
@@ -197,3 +197,16 @@ end
     sol = solve!(solver_on, body_aero)
     @test all(isfinite, sol.gamma_distribution)
 end
+
+@testset "solve! reports a solve that missed the tolerances" begin
+    body_aero = BodyAerodynamics([poststall_wing])
+    solver = Solver(body_aero; solver_type=LOOP, aerodynamic_model_type=VSM,
+        max_iterations=1)
+    set_va!(body_aero, [10.0, 0.0, 0.0])
+
+    sol = solve!(solver, body_aero)
+    @test !solver.lr.converged
+    @test sol.solver_status == FAILURE
+
+    @test_throws SolveFailure solve!(solver, body_aero; throw_on_fail=true)
+end


### PR DESCRIPTION
### TL;DR

`solve!` gains `throw_on_fail`, which turns a solve that missed the solver's tolerances or came back non-finite into a `SolveFailure` exception instead of a `VSMSolution` the caller has to inspect. The default is off, so nothing that solves today changes; SymbolicAWEModels.jl asks for the throw and is where this comes from (OpenSourceAWE/SymbolicAWEModels.jl#291).

### Why the failure belongs here

A caller that cannot use a failed solve has to know that `solver.lr.converged` and `sol.solver_status` exist, and has to re-derive "did this come back finite" for itself — including over `ForwardDiff.Dual` partials, which is not obvious. SymbolicAWEModels.jl carried exactly that: its own `VSMSolveFailure` exception, its own Dual-aware `finite_full`, and three call sites that re-checked the solver's own flag and threw. Review on that PR said the error should exist and be thrown here, which is right: whether a solve is usable is this package's question, not a caller's.

So `SolveFailure`, the `finite_full` check and the `throw` are here now, and the caller says once that it wants them.

### Why the default is off, and not on

Making `solve!` always throw was the first thing I tried, and two testsets in this repo say no. `NONLIN solve! re-runs across calls` solves at `va = [10, 0, 5]` — 26.6° — and `solve! artificial viscosity: attached no-op, post-stall finite` solves at 20° on a flat-plate LEI wing; both then assert on the result. Neither converges. The artificial-viscosity testset is explicit about what it wants there: a *finite* post-stall answer, not a converged one.

That is a real regime for this package, so the default keeps it: a post-stall solve still returns its `solver_status == FAILURE` solution and the caller decides. Flip the default if you would rather every caller be told — the two testsets above are what would have to move with it.

### What I found while measuring that

On the wing `test/solver/solver_test_wing.yaml` builds, at `va = [10, 0, 5]`, `NONLIN` misses the tolerances in all 1500 iterations while `LOOP` converges, and the two answers differ by 3.6% in peak circulation (`max|gamma|` 8.781 against 9.106). `NONLIN solve! re-runs across calls` has been asserting on that non-converged result. Nothing in this PR depends on it and I have not touched the test; filed as #283.

### What the coverage check caught

`codecov/patch` was the one red check on the first push, and it was right: the lines it named are the ones only the calling package exercised. The throw fires on non-convergence before `finite_full` is ever reached, so both of its methods, `showerror` and the whole converged branch of `throw_on_fail` had no test here at all. They do now — including a `Dual` whose partial is not finite, which is the case the method exists for.

### Verification

- [x] Reproduced first: n/a — new feature
- [x] `test/solver/test_solver.jl` red before (`UndefVarError: SolveFailure not defined in Main`), green after: 27 assertions, 9 of them new (juliaserver, Julia 1.12.7)
- [x] Local full suite: PASS — `test/runtests.jl`, every testset green, one pre-existing `@test_broken`. The coverage commit that followed it only adds assertions to `test/solver/test_solver.jl`, which was re-run on its own: 27/27
- [x] Docs build: `DOCSBUILD OK`
- Benchmark: n/a — the default path gains one `throw_on_fail || return sol` before the existing `return`
- Risk: the message a failure carries is the solver's, so a caller with several wings has to say which one it was itself.

### Scope

+94 / −18 across 7 files: `src/solver.jl` is `SolveFailure`, `finite_full` and the kwarg; the rest is two testsets, two docs entries and the changelog. Not stacked on #273 — it shares no source file with this, only `CHANGELOG.md`.
