### PR TITLE
CI: the code-coverage job's timeout-minutes is 30, tighter than the pl

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,7 +73,7 @@ jobs:
           prefix: ${{ runner.os == 'Linux' && 'xvfb-run -a' || '' }}
   test-with-code-coverage:
     name: Julia ${{ matrix.julia_version }} - ${{ matrix.os }} - ${{ matrix.julia_arch }} - with code coverage
-    timeout-minutes: 30
+    timeout-minutes: 50
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### TL;DR

`test-with-code-coverage` had `timeout-minutes: 30` while the plain `test` job, which does strictly less work, had 40 — so the slower job was the one that got killed. Raised the coverage job to 50.

### What the cap was actually cutting off

The job that was cancelled on #285 had finished. Attempt 2 of run [34401975496](https://github.com/OpenSourceAWE/VortexStepMethod.jl/actions/runs/34401975496/attempts/2), `Julia 1.12 - ubuntu-latest - x64 - with code coverage`: every step reports `success`, `Complete job` included, and the job is `cancelled` at 30m01s with `The job has exceeded the maximum execution time of 30m0s`.

The steps of that attempt: setup, cache and buildpkg 1m02s · `julia-runtest` 28m15s · `julia-processcoverage` 0m24s · `codecov` 0m02s · post-steps 0m15s. That is ≈29m58s of work against a 30m00s cap. Inside the 28m15s of `julia-runtest`, the suite itself was 10m06s (`6304 passed, 1 broken, 0 failed`); the other ~18 minutes were the cold precompile of the test environment after a `julia-actions/cache@v2` miss.

So this is not one unlucky run. Over the last 11 CI runs the coverage jobs land at 9, 10, 10, 10, 10, 12, 14, 14, 14, 16, 16, 17, 20, 20, 21, 26, 27, 28, 28 and 28 minutes — warm around 10–16, cold around 26–28. Three green runs came within two minutes of the cap. The plain `test` ubuntu jobs over the same runs take 21–29 minutes under their 40-minute cap, so the job doing less work had the more generous margin.

I went with 50 rather than 40 because 40 would only restore parity with the plain job, and the coverage job adds instrumentation, `julia-processcoverage` and the Codecov upload on top of the same suite. 50 against a 28-minute cold run is roughly the margin `test` already has at 40 against 29.

The failure mode this removes is worth naming: the check goes red with the suite entirely green, which reads at a glance exactly like a real test failure — the same PR had a genuine one (#287) two attempts earlier.

### Found while reading the file

`test-with-code-coverage` has no `if: github.event_name != 'pull_request' || github.event.pull_request.draft == false` guard, so it runs on draft PRs while `test` skips them. That is a behaviour change, not a timeout fix, so it is not in this diff.

`fail-fast: false` on both jobs is #279 and untouched here.

### Verification

- [x] Reproduced first: run 34401975496 attempt 2, coverage job `cancelled` at 30m01s with all steps `success`; attempt 1 `failure` at 16m05s, attempt 3 `success` at 10m17s
- [x] No Julia code changed, so no test covers this — the verification is CI on this branch running the coverage job under the new cap
- [x] Local CI mirror (`agent ci-local`): PASS in 9m
- [x] GitHub CI on this PR: PASS, both runs. The `Julia 1.12` coverage job took **28m18s** — green, and 1m42s inside the cap it used to run under. The `1.11` coverage job took 21m54s; the plain `test` ubuntu jobs 27m11s and 25m43s.
- Docs n/a · no REUSE in this repo · branch cut from `main` at 3f75701, no conflict
- Changelog: n/a, a CI job cap is not user-visible
- Risk: 50 is generous enough that a genuinely hung suite now burns 50 minutes of runner time before it is cut, instead of 30.

### Scope

+1 / -1 in `.github/workflows/CI.yml`, one integer. No stack.

Closes #288 · task `VortexStepMethod.jl-288`
