### PR TITLE
Tests write fixed filenames into the shared tempdir, so two suites on 

### DIFF
--- a/test/plotting/test_plotting.jl
+++ b/test/plotting/test_plotting.jl
@@ -24,23 +24,6 @@ using Test
 
 const makie_ext = Base.get_extension(VortexStepMethod, :VortexStepMethodMakieExt)
 
-# Helper to robustly delete files on platforms with occasional file locks
-safe_rm(path) = begin
-    if isfile(path)
-        try
-            rm(path; force=true)
-        catch
-            sleep(0.2)
-            try
-                rm(path; force=true)
-            catch
-                # last resort, ignore
-            end
-        end
-    end
-    nothing
-end
-
 global ram_wing = ram_air_matrix_wing(; n_panels=20, n_sections=4,
                           alpha_range=deg2rad.(-1:1.0:1),
                           delta_range=deg2rad.(-1:1.0:1))
@@ -72,7 +55,7 @@ function create_body_aero()
 end
 
 @testset "Plotting (Makie)" begin
-    save_dir = tempdir()
+    save_dir = mktempdir()
     body_aero = create_body_aero()
 
     fig = plot_geometry(
@@ -88,22 +71,10 @@ end
     @test_throws MethodError VortexStepMethod.show_plot(nothing)
     @test_nowarn VortexStepMethod.show_plot(fig)
 
-    @test isfile(joinpath(save_dir,
-                          "Rectangular_wing_geometry_angled_view.png"))
-    safe_rm(joinpath(save_dir,
-                     "Rectangular_wing_geometry_angled_view.png"))
-    @test isfile(joinpath(save_dir,
-                          "Rectangular_wing_geometry_front_view.png"))
-    safe_rm(joinpath(save_dir,
-                     "Rectangular_wing_geometry_front_view.png"))
-    @test isfile(joinpath(save_dir,
-                          "Rectangular_wing_geometry_side_view.png"))
-    safe_rm(joinpath(save_dir,
-                     "Rectangular_wing_geometry_side_view.png"))
-    @test isfile(joinpath(save_dir,
-                          "Rectangular_wing_geometry_top_view.png"))
-    safe_rm(joinpath(save_dir,
-                     "Rectangular_wing_geometry_top_view.png"))
+    for view_name in ("angled", "front", "side", "top")
+        @test isfile(joinpath(save_dir,
+                              "Rectangular_wing_geometry_$(view_name)_view.png"))
+    end
 
     # Initialize the solvers
     vsm_solver = Solver(body_aero; aerodynamic_model_type=VSM)
@@ -144,7 +115,6 @@ end
     )
     @test fig isa Figure
     @test isfile(joinpath(save_dir, "Rectangular_Wing_Polars.png"))
-    safe_rm(joinpath(save_dir, "Rectangular_Wing_Polars.png"))
 
     # Plot polars with CL vs CD (cl_over_cd=false)
     fig = plot_polars(
@@ -224,7 +194,7 @@ end
     )
     @test fig !== nothing
 
-    literature_csv = joinpath(tempdir(), "polar_literature_aoa.csv")
+    literature_csv = joinpath(save_dir, "polar_literature_aoa.csv")
     open(literature_csv, "w") do io
         write(io, "AOA,cl,cd,cs\n")
         write(io, "0.0,0.1,0.01,0.0\n")
@@ -232,20 +202,16 @@ end
         write(io, "10.0,0.9,0.04,0.02\n")
     end
 
-    try
-        fig = plot_polars(
-            Solver[],
-            BodyAerodynamics[],
-            ["Literature"],
-            literature_path_list=[literature_csv],
-            title="Literature AOA Header",
-            is_save=false,
-            is_show=false,
-        )
-        @test fig !== nothing
-    finally
-        safe_rm(literature_csv)
-    end
+    fig = plot_polars(
+        Solver[],
+        BodyAerodynamics[],
+        ["Literature"],
+        literature_path_list=[literature_csv],
+        title="Literature AOA Header",
+        is_save=false,
+        is_show=false,
+    )
+    @test fig !== nothing
 
     # Unit tests for shared extract_literature_polar_data
     using DelimitedFiles
@@ -285,7 +251,7 @@ end
         bad_data, "bad.csv")
 
     # CM coefficient extraction from literature data
-    cm_csv = tempname() * "_lit_cm.csv"
+    cm_csv = joinpath(save_dir, "lit_cm.csv")
     open(cm_csv, "w") do io_cm
         write(io_cm,
             "alpha,cl,cd,cs,cmx,cmy,cmz\n" *
@@ -298,10 +264,9 @@ end
     @test Float64.(cm_result.cmx) == [0.001, 0.004]
     @test Float64.(cm_result.cmy) == [0.002, 0.005]
     @test Float64.(cm_result.cmz) == [0.003, 0.006]
-    safe_rm(cm_csv)
 
     # angle_type="side_slip" literature loading
-    beta_csv = tempname() * "_lit_beta.csv"
+    beta_csv = joinpath(save_dir, "lit_beta.csv")
     open(beta_csv, "w") do io_beta
         write(io_beta,
             "alpha,beta,cl,cd,cs\n" *
@@ -312,10 +277,9 @@ end
         readdlm(beta_csv, ','), beta_csv;
         angle_type="side_slip")
     @test beta_result.polar_data[1] == [0.0, 5.0]
-    safe_rm(beta_csv)
 
     # Integration: literature CSV with AoA alias and no CS
-    lit_no_cs_path = tempname() * "_lit_no_cs.csv"
+    lit_no_cs_path = joinpath(save_dir, "lit_no_cs.csv")
     open(lit_no_cs_path, "w") do io_no_cs
         write(io_no_cs, "aoa,cl,cd\n0.0,0.10,0.010\n5.0,0.20,0.020\n")
     end
@@ -328,10 +292,9 @@ end
         is_show=false
     )
     @test fig_lit_no_cs !== nothing
-    safe_rm(lit_no_cs_path)
 
     # Integration: missing CD column should fail
-    lit_bad_path = tempname() * "_lit_bad.csv"
+    lit_bad_path = joinpath(save_dir, "lit_bad.csv")
     open(lit_bad_path, "w") do io_bad
         write(io_bad, "alpha,cl\n0.0,0.10\n5.0,0.20\n")
     end
@@ -343,10 +306,9 @@ end
         is_save=false,
         is_show=false
     )
-    safe_rm(lit_bad_path)
 
     # Test show_moments=true with literature data
-    cm_lit_path = tempname() * "_lit_moments.csv"
+    cm_lit_path = joinpath(save_dir, "lit_moments.csv")
     open(cm_lit_path, "w") do io_cm_lit
         write(io_cm_lit,
             "alpha,cl,cd,cs,cmx,cmy,cmz\n" *
@@ -363,10 +325,9 @@ end
         is_show=false
     )
     @test fig_moments !== nothing
-    safe_rm(cm_lit_path)
 
     # Test show_moments=false (default)
-    no_cm_path = tempname() * "_lit_no_cm.csv"
+    no_cm_path = joinpath(save_dir, "lit_no_cm.csv")
     open(no_cm_path, "w") do io_no_cm
         write(io_no_cm,
             "alpha,cl,cd\n" *
@@ -382,7 +343,6 @@ end
         is_show=false
     )
     @test fig_no_moments !== nothing
-    safe_rm(no_cm_path)
 
     # Tests for save_plot function
     @testset "_active_backend_prefers_vector_output" begin
@@ -410,60 +370,40 @@ end
     active_backend_prefers_vector_output =
         getfield(makie_ext, :_active_backend_prefers_vector_output)
 
-    save_test_dir = tempdir()
-    
-    # Test 1: save_plot with explicit data_type (".png")
-    VortexStepMethod.save_plot(fig, save_test_dir, "test_explicit_png", data_type=".png")
-    @test isfile(joinpath(save_test_dir, "test_explicit_png.png"))
-    safe_rm(joinpath(save_test_dir, "test_explicit_png.png"))
+    # Explicit data_type picks the extension.
+    VortexStepMethod.save_plot(fig, save_dir, "test_explicit_png", data_type=".png")
+    @test isfile(joinpath(save_dir, "test_explicit_png.png"))
 
-    # Test 2: save_plot with explicit data_type (".pdf")
-    VortexStepMethod.save_plot(fig, save_test_dir, "test_explicit_pdf", data_type=".pdf")
-    @test isfile(joinpath(save_test_dir, "test_explicit_pdf.pdf"))
-    safe_rm(joinpath(save_test_dir, "test_explicit_pdf.pdf"))
+    VortexStepMethod.save_plot(fig, save_dir, "test_explicit_pdf", data_type=".pdf")
+    @test isfile(joinpath(save_dir, "test_explicit_pdf.pdf"))
 
-    # Test 3: save_plot with data_type=nothing (backend-aware detection)
-    backend_aware_dir = mktempdir()
-    try
-        VortexStepMethod.save_plot(fig, backend_aware_dir, "test_backend_aware", data_type=nothing)
-        pdf_path = joinpath(backend_aware_dir, "test_backend_aware.pdf")
-        png_path = joinpath(backend_aware_dir, "test_backend_aware.png")
-        expected_ext = active_backend_prefers_vector_output(Makie) ? ".pdf" : ".png"
+    # data_type=nothing picks it from the active backend, and writes only that one.
+    VortexStepMethod.save_plot(fig, save_dir, "test_backend_aware", data_type=nothing)
+    pdf_path = joinpath(save_dir, "test_backend_aware.pdf")
+    png_path = joinpath(save_dir, "test_backend_aware.png")
+    expected_ext = active_backend_prefers_vector_output(Makie) ? ".pdf" : ".png"
+    @test xor(isfile(pdf_path), isfile(png_path))
+    @test isfile(joinpath(save_dir, "test_backend_aware" * expected_ext))
 
-        @test xor(isfile(pdf_path), isfile(png_path))
-        @test isfile(joinpath(backend_aware_dir, "test_backend_aware" * expected_ext))
-    finally
-        safe_rm(joinpath(backend_aware_dir, "test_backend_aware.pdf"))
-        safe_rm(joinpath(backend_aware_dir, "test_backend_aware.png"))
-        rm(backend_aware_dir; force=true, recursive=true)
+    # Spaces become underscores and percent signs become "pct" in the file name.
+    VortexStepMethod.save_plot(fig, save_dir, "test with spaces", data_type=".png")
+    @test isfile(joinpath(save_dir, "test_with_spaces.png"))
 
-        # Test 4: save_plot with title containing spaces (should be sanitized to underscores)
-        VortexStepMethod.save_plot(fig, save_test_dir, "test with spaces", data_type=".png")
-        @test isfile(joinpath(save_test_dir, "test_with_spaces.png"))
-        safe_rm(joinpath(save_test_dir, "test_with_spaces.png"))
+    VortexStepMethod.save_plot(fig, save_dir, "test%efficiency", data_type=".png")
+    @test isfile(joinpath(save_dir, "testpctefficiency.png"))
 
-        # Test 5: save_plot with title containing percent signs (should be sanitized to "pct")
-        VortexStepMethod.save_plot(fig, save_test_dir, "test%efficiency", data_type=".png")
-        @test isfile(joinpath(save_test_dir, "testpctefficiency.png"))
-        safe_rm(joinpath(save_test_dir, "testpctefficiency.png"))
+    VortexStepMethod.save_plot(fig, save_dir, "test %efficiency metric", data_type=".png")
+    @test isfile(joinpath(save_dir, "test_pctefficiency_metric.png"))
 
-        # Test 6: save_plot with title containing both spaces and percent signs
-        VortexStepMethod.save_plot(fig, save_test_dir, "test %efficiency metric", data_type=".png")
-        @test isfile(joinpath(save_test_dir, "test_pctefficiency_metric.png"))
-        safe_rm(joinpath(save_test_dir, "test_pctefficiency_metric.png"))
+    # A save_path that does not exist yet is created.
+    nested_dir = joinpath(save_dir, "nested_save_plot_dir")
+    @test !isdir(nested_dir)
+    VortexStepMethod.save_plot(fig, nested_dir, "test_nested_dir", data_type=".png")
+    @test isdir(nested_dir)
+    @test isfile(joinpath(nested_dir, "test_nested_dir.png"))
 
-        # Test 7: save_plot creates directory if it doesn't exist
-        nested_dir = joinpath(save_test_dir, "nested_save_plot_dir")
-        !isdir(nested_dir) && @test !isdir(nested_dir)
-        VortexStepMethod.save_plot(fig, nested_dir, "test_nested_dir", data_type=".png")
-        @test isdir(nested_dir)
-        @test isfile(joinpath(nested_dir, "test_nested_dir.png"))
-        safe_rm(joinpath(nested_dir, "test_nested_dir.png"))
-        rm(nested_dir; force=true)
-
-        # Test 8: save_plot raises error when save_path is nothing
-        @test_throws ArgumentError VortexStepMethod.save_plot(fig, nothing, "test_title", data_type=".png")
-    end
+    @test_throws ArgumentError VortexStepMethod.save_plot(fig, nothing, "test_title",
+                                                          data_type=".png")
 end
 
 """

--- a/test/ram_geometry/test_kite_geometry.jl
+++ b/test/ram_geometry/test_kite_geometry.jl
@@ -10,9 +10,9 @@ using Interpolations
 using Serialization
 
 @testset "Kite Geometry Tests" begin
-    # Test data
-    test_obj_path = joinpath(tempdir(), "test.obj")
-    test_dat_path = joinpath(tempdir(), "test.dat")
+    work_dir = mktempdir()
+    test_obj_path = joinpath(work_dir, "test.obj")
+    test_dat_path = joinpath(work_dir, "test.dat")
     
     @testset "OBJ File Reading" begin
         # Create minimal test OBJ file
@@ -90,7 +90,6 @@ using Serialization
         end
         
         # Create test airfoil data file
-        test_dat_path = joinpath(tempdir(), "test.dat")
         write(test_dat_path, "1.0 0.0\n0.0 0.0\n-1.0 0.0\n")
         
         # Create polar data
@@ -112,9 +111,9 @@ using Serialization
         cd_matrix[end] = NaN
         cm_matrix[end] = NaN
         
-        cl_polar_path = joinpath(tempdir(), test_dat_path[1:end-4] * "_cl_polar.csv")
-        cd_polar_path = joinpath(tempdir(), test_dat_path[1:end-4] * "_cd_polar.csv")
-        cm_polar_path = joinpath(tempdir(), test_dat_path[1:end-4] * "_cm_polar.csv")
+        cl_polar_path = test_dat_path[1:end-4] * "_cl_polar.csv"
+        cd_polar_path = test_dat_path[1:end-4] * "_cd_polar.csv"
+        cm_polar_path = test_dat_path[1:end-4] * "_cm_polar.csv"
         
         # Write matrices to CSV
         write_aero_matrix(cl_polar_path, cl_matrix, deg2rad.(alphas), deg2rad.(d_trailing_edge_angles), "C_l")
@@ -175,7 +174,4 @@ using Serialization
         # Rebuild against ram_air_matrix_wing() geometry once its numerics are set.
         @test_skip false
     end
-
-    rm(test_obj_path)
-    rm(test_dat_path)
 end

--- a/test/yaml_geometry/test_load_polar_data.jl
+++ b/test/yaml_geometry/test_load_polar_data.jl
@@ -6,14 +6,9 @@ using YAML
 using Logging
 
 @testset "load_polar_data Function Tests" begin
-    # Setup temporary files for testing
-    test_csv_path = joinpath(tempdir(), "test_polar.csv")
-    
-    # Clean up function
-    function cleanup_test_files()
-        isfile(test_csv_path) && rm(test_csv_path; force=true)
-    end
-    
+    work_dir = mktempdir()
+    test_csv_path = joinpath(work_dir, "test_polar.csv")
+
     @testset "Valid CSV File" begin
         # Create a valid CSV file with polar data
         csv_content = """alpha,cl,cd,cm
@@ -72,7 +67,7 @@ using Logging
     end
     
     @testset "Missing File" begin
-        nonexistent_path = joinpath(tempdir(), "nonexistent.csv")
+        nonexistent_path = joinpath(work_dir, "nonexistent.csv")
         aero_data, aero_model = suppress_warnings(() -> load_polar_data(nonexistent_path))
         
         @test aero_model == INVISCID
@@ -120,7 +115,4 @@ using Logging
         @test aero_model == INVISCID
         @test aero_data === nothing
     end
-    
-    # Cleanup after all tests
-    cleanup_test_files()
 end

--- a/test/yaml_geometry/test_wing_constructor.jl
+++ b/test/yaml_geometry/test_wing_constructor.jl
@@ -6,32 +6,19 @@ using YAML
 using Logging
 
 @testset "Wing Constructor Tests" begin
-    # Setup temporary files for testing
-    test_yaml_path = joinpath(tempdir(), "test_wing.yaml")
-    test_polar_dir = joinpath(tempdir(), "polars")
-    
-    # Clean up function
-    function cleanup_test_files()
-        test_dir = dirname(test_yaml_path)
-        for file in [test_yaml_path, 
-                     joinpath(test_dir, "standard_airfoil.csv"),
-                     joinpath(test_dir, "alternate_airfoil.csv")]
-            isfile(file) && rm(file; force=true)
-        end
-        isdir(test_polar_dir) && rm(test_polar_dir; recursive=true, force=true)
-    end
-    
-    # Create polar data directory and files
+    work_dir = mktempdir()
+    test_yaml_path = joinpath(work_dir, "test_wing.yaml")
+    test_polar_dir = joinpath(work_dir, "polars")
+
+    # The YAML files under test reach their polars both through `polars/<id>.csv`
+    # and by bare name beside the YAML, so each airfoil is copied to both places.
     mkpath(test_polar_dir)
-    
-    # Copy the actual polar files to the temp directory for tests that reference them
-    cp(test_data_path("yaml_geometry", "standard_airfoil.csv"), joinpath(test_polar_dir, "1.csv"); force=true)
-    cp(test_data_path("yaml_geometry", "alternate_airfoil.csv"), joinpath(test_polar_dir, "2.csv"); force=true)
-    
-    # Also copy them to the test directory itself for direct reference tests
-    test_dir = dirname(test_yaml_path)
-    cp(test_data_path("yaml_geometry", "standard_airfoil.csv"), joinpath(test_dir, "standard_airfoil.csv"); force=true)
-    cp(test_data_path("yaml_geometry", "alternate_airfoil.csv"), joinpath(test_dir, "alternate_airfoil.csv"); force=true)
+    for (airfoil, polar_name) in (("standard_airfoil.csv", "1.csv"),
+                                  ("alternate_airfoil.csv", "2.csv"))
+        source = test_data_path("yaml_geometry", airfoil)
+        cp(source, joinpath(test_polar_dir, polar_name))
+        cp(source, joinpath(work_dir, airfoil))
+    end
     
     @testset "Valid YAML Wing Construction" begin
         # Use the actual YAML file from the test data
@@ -156,7 +143,7 @@ wing_airfoils:
     
     @testset "Relative Path Resolution" begin
         # Test that relative paths in CSV files are resolved relative to YAML file
-        subdir = joinpath(tempdir(), "subtest")
+        subdir = joinpath(work_dir, "subtest")
         mkpath(subdir)
         
         # Copy the simple wing file to subdirectory
@@ -174,9 +161,6 @@ wing_airfoils:
         @test wing.unrefined_sections[1].aero_data isa Tuple
         @test wing.unrefined_sections[2].aero_model == POLAR_VECTORS
         @test wing.unrefined_sections[2].aero_data isa Tuple
-        
-        # Cleanup
-        rm(subdir; recursive=true)
     end
     
     @testset "Complex Wing Geometry" begin
@@ -275,7 +259,4 @@ wing_airfoils:
         @test standard_wing isa Wing
         @test length(standard_wing.unrefined_sections) == 2
     end
-    
-    # Cleanup after all tests
-    cleanup_test_files()
 end


### PR DESCRIPTION
### TL;DR

Four test files wrote fixed filenames straight into `tempdir()` — `/tmp` when `TMPDIR` is unset, and so shared by every suite running on the box — where a second run's cleanup can land between one run's save and its `isfile` assertion. Each affected testset now opens its own `mktempdir()`, and the hand cleanup that existed only to keep that shared directory tidy goes with it.

### What was wrong

`tempdir()` is one directory for the whole machine. The agent box runs several VortexStepMethod worktrees' suites at once, and they were all writing the same names into it: `Rectangular_wing_geometry_*_view.png`, `Rectangular_Wing_Polars.png`, `test_polar.csv`, `test_wing.yaml`, `polars/`, `subtest/`, `test.obj`, `test.dat`. Whoever ran second overwrote or deleted the first run's fixture, and the first run's next assertion failed.

The evidence for it being sharing rather than code is in #285's `agent ci-local` (`Plotting (Makie) | 4 passed 1 failed 5 total`, the failure being the `angled_view.png` `isfile`) plus the same commit passing 58/58 on the next run. GitHub CI never sees it: one suite per runner.

I reproduced the mechanism directly rather than by racing whole suites. Two threads, one writing `test_load_polar_data.jl`'s "Valid CSV File" fixture and reading it straight back, one writing that file's "Empty CSV File" case, 400 rounds:

```
shared tempdir()  : 395 / 400 reads lost
per-run mktempdir : 0 / 400 reads lost
```

### What changed

`test/obj_adapter/`, `test/surfplan/` and `test/airfoil_aero/` already do this, so the fix is to follow them: one `mktempdir()` per testset, every path built from it. Nothing about what the tests assert changes.

`mktempdir()` deletes itself at process exit, so every `rm` that existed only to keep `/tmp` tidy came out with it, and that is most of the diff:

- `test_plotting.jl`'s `safe_rm` helper — a two-attempt retry-and-swallow delete — and its 25 call sites. With no caller left the helper went too.
- The `try`/`finally` around the `save_plot` tests. Its `finally` block had accumulated five of the eight tests, which therefore ran as cleanup: if test 3 threw, tests 4–8 ran anyway and the testset reported whatever they found. They are now plain sequential tests.
- `!isdir(nested_dir) && @test !isdir(nested_dir)`, written that way because the directory might hold a previous run's leftovers, is now the unconditional `@test !isdir(nested_dir)` it was meant to be.
- `cleanup_test_files()` in both `yaml_geometry` tests, and the trailing `rm(test_obj_path)` / `rm(test_dat_path)` in `test_kite_geometry.jl`.

Two things I found on the way and folded in, both in files already open in this diff. `test_kite_geometry.jl` built its polar paths as `joinpath(tempdir(), test_dat_path[1:end-4] * "_cl_polar.csv")` — `test_dat_path` is absolute, so `joinpath` discarded the prefix and the call did nothing; the path is now written directly. And `test_kite_geometry.jl` re-declared `test_dat_path` inside a nested testset with the value it already had.

Three of the four `cp` calls in `test_wing_constructor.jl` differed only in which airfoil and which name, so they are one loop over the two airfoils.

### Where I would push back

`/tmp` on this box still holds `test_cl_polar.csv`, `test_cd_polar.csv`, `test_cm_polar.csv` and `test_info.bin` — files the old code never deleted at all, only overwrote. Their timestamps moved while I was working on this (00:22 → 00:33), and `/tmp/test_polar.csv` was deleted under me by somebody's `cleanup_test_files()`, so the collision is not hypothetical on this box. Those leftovers belong to the other worktrees' copies of these tests and will clear as this lands.

Left alone deliberately: `test/test_data_utils.jl:164` also writes into `tempdir()`, but with a `randstring(8)` in the name, so two runs cannot collide there.

No changelog entry — nothing user-visible changes.

### Verification

- [x] Reproduced first: `shared tempdir() : 395 / 400 reads lost` against `per-run mktempdir : 0 / 400`, two threads on the fixed path this suite uses
- [x] `test/yaml_geometry/` + `test/ram_geometry/` via `runtests.jl` (juliaserver): 199 pass, 1 broken (the pre-existing `@test_skip`), 0 fail, 31.4 s
- [x] After that run `/tmp` gained none of the fixed names — the `test_c*_polar.csv` sitting there belong to another worktree's copy of the unfixed test
- [x] All four files parse clean
- [x] `agent ci-local`: PASS in 7m — that is where `test/plotting/test_plotting.jl` ran, and where #285 saw the failure. GitHub CI triggers on `pull_request`, so it starts when this PR opens
- [ ] The plotting testset could not be run in the juliaserver session itself: it needs `CairoMakie`, a `test/`-only dependency, and this worktree has no `test/Manifest-v1.12.toml` (nor `examples/`), which §2 forbids me creating by hand
- [ ] `jetls check` not run — `jetls` is not on this box
- Docs: n/a, no public symbol changed · REUSE: n/a, repo has no `bin/reuse_lint` · up to date with `origin/main` (3f75701)
- Risk: the `save_plot` tests now share one directory with the earlier `plot_geometry`/`plot_polars` saves instead of a dedicated one. The names do not overlap, and the `xor(isfile(pdf), isfile(png))` check still starts from a directory holding neither `test_backend_aware.pdf` nor `.png`, but that assertion is the one to look at first if the plotting testset misbehaves.

### Scope

+79 / −170 across 4 files, tests only. The net −91 is the deleted cleanup: `safe_rm` and its call sites, two `cleanup_test_files` helpers, and the `try`/`finally` that held five tests. No stack.


Closes #286 · task `VortexStepMethod.jl-286`
