### PR TITLE
Fit the contour generate_airfoils is handed, not a second wrap of it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
 
 ### Fixed
 
+- `generate_airfoils` fits the contour it is handed rather than shrink-wrapping it a
+  second time. Both adapters wrap before they call, with the `wrap_method` their
+  settings name, so the second wrap discarded that setting and degenerated the Kulfan
+  fit: on the SK100's 45 mesh sections nine came out with `.dat` coordinates at 1e2 to
+  1e4 instead of 0..1, and any consumer mapping the mesh onto a structure rejected the
+  geometry.
 - The `NONLIN` solver backtracks along each Newton step instead of always taking
   it whole, so it converges past stall where the full step used to cycle: on the
   `test/solver/solver_test_wing.yaml` wing at 26.6° it stopped 3.6% below `LOOP`'s

--- a/src/airfoil_aero/geometry_gen.jl
+++ b/src/airfoil_aero/geometry_gen.jl
@@ -42,7 +42,8 @@ function generate_airfoils(airfoils, output_dir::String;
             alphas = deg2rad.(collect(Float64, alpha_range))
             deltas = isnothing(delta_range) ? [0.0] :
                 deg2rad.(collect(Float64, delta_range))
-            aero, sols = generate_airfoil_aero(aero_solver, af.x_fit, af.y_fit;
+            aero, sols = generate_airfoil_aero(aero_solver,
+                fit_kulfan_parameters(af.x_fit, af.y_fit, LeastSquaresFit());
                 alpha_range=alphas, delta_range=deltas,
                 reynolds_number=Float64(Re), crease_frac)
             clvals = collect(sol.cl for sol in sols[1])

--- a/test/airfoil_aero/test_airfoil_aero.jl
+++ b/test/airfoil_aero/test_airfoil_aero.jl
@@ -271,3 +271,20 @@ end
     cp(joinpath(weights_dir, "nn-medium.npz"), joinpath(partial, "nn-medium.npz"))
     @test_throws ErrorException load_neuralfoil_model("medium"; weights_dir=partial)
 end
+
+@testset "generate_airfoils fits the wrapped contour it is handed" begin
+    x_raw, y_raw = read_dat_coords(joinpath(@__DIR__, "data", "test_airfoil.dat"))
+    x_fit, y_fit = shrink_wrap(x_raw, y_raw, ShrinkWrap(clearance=0.0))
+    _, fitted_y = kulfan_to_coordinates(
+        fit_kulfan_parameters(x_fit, y_fit, LeastSquaresFit()))
+    out = mktempdir()
+    _, ok = generate_airfoils([(; id=1, x_fit, y_fit, x_raw, y_raw)], out;
+        Re=5e5, alpha_range=-2:2:2,
+        aero_solver=NeuralFoilSolver(model_size="medium"), verbose=false)
+    @test ok == [1]
+    _, written_y = read_dat_coords(joinpath(out, "airfoils", "1.dat"))
+    # A second shrink wrap inflates the section by its own clearance, 0.006, which is
+    # three orders of magnitude above the resampling error this tolerance allows.
+    @test maximum(abs, collect(extrema(written_y)) .-
+                       collect(extrema(fitted_y))) < 1e-4
+end


### PR DESCRIPTION
### TL;DR

`generate_airfoils` shrink-wrapped a contour both of its callers had already wrapped, and that second wrap tips the least-squares Kulfan fit into rank deficiency for about a fifth of the SK100's sections, writing their airfoil `.dat` files at 1e4 scale. It now fits the contour it is given — which is what its own docstring says it receives — so the `wrap_method` the caller configured is the only one that runs. Closes #293.

### What was wrong

Both front ends wrap before they call. `obj_to_yaml` does it at `obj_to_yaml.jl:221` and the Surfplan adapter at `SurfplanAdapter.jl:71`, each with the `wrap_method` its settings name, and both hand the result in as `x_fit`/`y_fit`. `generate_airfoils` then called `generate_airfoil_aero(solver, x::Vector, y::Vector)`, whose whole job is to `shrink_wrap` a *raw* slice before fitting — and with a bare `ShrinkWrap()`, so the configured wrap was quietly replaced by the default one as well.

Wrapping a wrapped contour is not a small perturbation of the fit. The second wrap rounds an already-rounded convex corner into an arc of near-coincident vertices; `smoothed_curvature` divides the turn across a span of order 1e-16, so `resample_arc`'s curvature-weighted measure blows up and crowds most of the upper stations into one narrow band of x. The upper Bernstein block of the fit matrix then goes numerically singular — on SK100 section 16, `cond(A)` moves from 1.07e3 to 2.52e11 — and `A \ y_norm` at `kulfan.jl:147` returns weights of order 1e5. The **residual is normal**, because those weights cancel on the stations they were fitted to; `kulfan_to_coordinates` re-evaluates them on its own cosine grid, where they do not, and y reaches -13013.

Nine of the 45 sections come out that way, and the contours written from them — `airfoils/{6,8,9,10,12,16,27,29,43}.dat` — carry coordinates from 1e2 to 1e4 where a clean section is 0..1. Nothing in the pipeline notices: the polars still solve, the node counts are still right, the run reports every airfoil as converged, and the geometry is only refused much later by a consumer that maps the mesh onto a structure. In `SymbolicAWEModels` that reads `AeroPressure wing 1: max surface-node→point distance is 35776.8× the local chord, exceeding frame_tol_frac=2.0`, which is where this was found: it is what stopped 1-Bart-1/BeyondTheSim.jl#17 from building a model at all.

### How the test pins it

The written contour has to be the fit of the contour that was handed in. Wrapping again inflates the section by the default clearance, 0.006, so the test measures the extremes of the written `.dat` against `kulfan_to_coordinates(fit_kulfan_parameters(x_fit, y_fit, LeastSquaresFit()))` and allows 1e-4. With the second wrap that gap is 6.27e-3; without it, 6.31e-6 — the resampling error, three orders of magnitude clear of the tolerance. It uses the suite's own `test_airfoil.dat`, so it needs no fixture, and it fails on any airfoil rather than only on the sections whose fit happens to blow up.

### Where I would push back

This removes the trigger, not the fragility. The fit at `kulfan.jl:147` is an unregularised `A \ y` with no rank check, no coefficient bound and no check on what `kulfan_to_coordinates` then produces — while `KulfanBasis` in `deform.jl:44` already ridge-regularises the same kind of solve. Any other input that crowds the resample will do the same thing just as silently, and `deform_section` still wraps once more per deflection on a default `ShrinkWrap()` rather than the caller's. Raised separately rather than widened into this diff.

One thing worth knowing when judging generated tables: a blown-up section is not always obvious from its bounding box. `10_d10.dat` looks normalised because it was rescaled by a large chord — its lower surface is a constant `min_clearance/chord`. Thickness is the honest check, not `x ∈ [0, 1]`.

### Verification

- [x] Reproduced first: `airfoils/10.dat` starting `144.26245312 47009.20858195`, and the consumer's `max surface-node→point distance is 35776.8× the local chord`
- [x] `test/airfoil_aero/test_airfoil_aero.jl` red before the fix (1 passed, 1 failed), green after (all testsets pass, exit 0)
- [ ] `test/obj_adapter/test_obj_adapter.jl` not run locally: this worktree has no juliaserver session of its own — its directory name collides with another task's upstream worktree — so the tests were run from the dependent's environment, which does not carry the suite's `YAML` and `Aqua`. GitHub CI is the authority for the rest of the suite.
- Risk: the fix changes generated geometry for every user of both adapters. Tables generated before it do not reproduce after it — a section that was fitting a doubly-wrapped contour now fits the caller's, so its polars move by the difference between one wrap and two.

### Scope

+19 / -1 across 3 files: the one call in `src/airfoil_aero/geometry_gen.jl`, its regression test, and the changelog entry. No stack — no open pull request here touches either file.

From 1-Bart-1/BeyondTheSim.jl#17 · task `BeyondTheSim.jl-17`
