### PR TITLE
plot_slices_3d builds its own deflection filename tag, so it finds no 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 
 ### Fixed
 
+- `plot_slices_3d` on a generated output directory draws the deflected contour for
+  every deflection that was generated, not just positive whole degrees. It built its
+  own `_d<degrees>.dat` filename tag instead of the `delta_suffix` one the files were
+  written under, which spells a minus sign `m` and a decimal point `p`, so
+  `delta=-10` or `delta=2.5` found no `.dat` and drew nothing.
 - The `NONLIN` solver backtracks along each Newton step instead of always taking
   it whole, so it converges past stall where the full step used to cycle: on the
   `test/solver/solver_test_wing.yaml` wing at 26.6° it stopped 3.6% below `LOOP`'s

--- a/ext/VortexStepMethodMakieExt.jl
+++ b/ext/VortexStepMethodMakieExt.jl
@@ -1601,8 +1601,7 @@ their written `.dat` airfoils — raw slice, wrap, and the `delta`-degree deform
 when it was generated — assembled for
 [`plot_slices_3d`](@ref VortexStepMethod.ObjAdapter.plot_slices_3d). Nothing is
 re-sliced or re-wrapped; only the Kulfan fits of the stored coordinates are
-recomputed (via
-`fit_pts`), exactly as the polar pipeline fits them.
+recomputed (via `fit_pts`), exactly as the polar pipeline fits them.
 """
 function generated_slices(out_dir, delta, fit_pts)
     geom = VortexStepMethod.YAML.load_file(joinpath(out_dir, "geometry.yaml"))
@@ -1611,9 +1610,8 @@ function generated_slices(out_dir, delta, fit_pts)
     les = [Float64.(r[2:4]) for r in rows]
     tes = [Float64.(r[5:7]) for r in rows]
     n = length(rows)
-    deg = round(float(delta); digits=1)
-    tag = "_d" * (deg == round(deg) ? string(Int(deg)) : string(deg)) * ".dat"
-    missing_deltas = String[]
+    tag = "_$(AirfoilAero.delta_suffix(deg2rad(delta))).dat"
+    missing_dats = String[]
     slices = map(1:n) do i
         id = rows[i][1]
         tangent = normalize(les[min(i + 1, n)] .- les[max(i - 1, 1)])
@@ -1631,16 +1629,16 @@ function generated_slices(out_dir, delta, fit_pts)
                 def3d = map_airfoil_3d(les[i], tes[i], tangent, xd, yd)
                 d2 = (; d2..., def=Point2f.(xd, yd), def_kulfan=fit_pts(xd, yd))
             else
-                push!(missing_deltas, basename(dpath))
+                push!(missing_dats, relpath(dpath, out_dir))
             end
         end
         (; centroid=Point3f((les[i] .+ tes[i]) ./ 2), label_y=les[i][2],
          cloud3d=map_airfoil_3d(les[i], tes[i], tangent, xr, yr),
          wrap3d=map_airfoil_3d(les[i], tes[i], tangent, xw, yw), def3d, d2)
     end
-    isempty(missing_deltas) ||
-        @warn "No generated .dat for delta=$(delta)° ($(join(missing_deltas, ", ")));" *
-              " generated deflections are named airfoils/<i>_d<degrees>.dat."
+    isempty(missing_dats) ||
+        @warn "No generated .dat for delta=$(delta)° in $out_dir: " *
+              join(missing_dats, ", ")
     return slices, reduce(hcat, les), reduce(hcat, tes)
 end
 

--- a/test/plotting/test_plotting.jl
+++ b/test/plotting/test_plotting.jl
@@ -563,4 +563,18 @@ end
     ax_lw = Axis3(fig_lw[1, 1])
     @test_nowarn Makie.plot!(ax_lw, plain_body; border_linewidth=3.0)
 end
+
+@testset "generated_slices reads the deflected .dat under its generated name" begin
+    generated_slices = getfield(makie_ext, :generated_slices)
+    gen_dir, _ = ram_air_matrix_dir(; n_sections=4,
+        alpha_range=deg2rad.(-1:1.0:1), delta_range=deg2rad.(-1:1.0:1))
+    fit_pts(x, y) = Point2f.(x, y)
+
+    for delta in (-1.0, 1.0)
+        slices, _, _ = @test_nowarn generated_slices(gen_dir, delta, fit_pts)
+        @test all(s -> !isempty(s.d2.def), slices)
+        @test all(s -> s.def3d !== nothing, slices)
+    end
+end
+
 nothing


### PR DESCRIPTION
### TL;DR

`generated_slices` built its own `_d<degrees>.dat` filename tag instead of calling `AirfoilAero.delta_suffix`, the function that named the file when `generate_airfoils` wrote it, so `plot_slices_3d(dir; delta=...)` silently drew no deflected contour for any negative or fractional deflection. It now asks `delta_suffix` for the name, leaving one source for it.

### The red check is #300, not this diff

`Test end-user and developer setup` fails here on `examples/ram_air_kite.jl`, twice on the same commit, and it is not this change. That example asks for `delta=1.0`, and for a positive whole degree the old hand-rolled tag and `delta_suffix(deg2rad(1.0))` produce the identical name `_d1.dat` — the two schemes diverge only on a minus sign or a decimal point. I evaluated both (`_d1.dat` from each) and then checked them against a generated directory built on this box from the example's own settings: same string, same file, all ten sections.

What actually fails is that the `_d1.dat` the XFoil sweep wrote on the runner is full of `NaN NaN` rows, so the strict `read_dat_coordinates` returns zero points and `fit_kulfan_parameters` throws on an empty `argmin`. `write_section_aero` writes every deflected column unconditionally, three lines above the guard that stops it writing an all-NaN *zero*-deflection file. Worse than the crash: `read_section_aero` uses the lenient `read_dat`, which parses `NaN` happily, so `Wing(yaml)` five lines earlier had already loaded a wing whose contour interpolants are NaN at every delta — including 0° — without a word. The crash on line 79 is the only thing that surfaced it. Filed as #300 with the mechanism and a ten-line reproduction.

I am deliberately not silencing it here by having `generated_slices` treat an unreadable `.dat` as missing. That would turn this check green while hiding a pipeline that quietly produces NaN wings, and it is a second idea in a diff that holds one. #299 should land after #300, or on the reviewer's judgement that the red check is pre-existing.

### What was wrong

The two schemes agree only on positive whole degrees: `delta_suffix` writes a minus sign as `m` and a decimal point as `p` (`_dm3.dat`, `_d2p5.dat`), the local tag wrote them literally (`_d-3.dat`, `_d2.5.dat`). On the SK100's `delta_range = -40:10:40` that is four of the eight non-zero deflections, and the warning the user got named the wrong scheme, so it pointed away from the real files.

Reproduced on the test suite's own generated ram-air directory (`delta_range = -1:1:1`), which writes `airfoils/<i>_dm1.dat`:

```
┌ Warning: No generated .dat for delta=-1.0° (4_d-1.dat, 3_d-1.dat, 2_d-1.dat, 1_d-1.dat); generated deflections are named airfoils/<i>_d<degrees>.dat.
└ @ VortexStepMethodMakieExt ext/VortexStepMethodMakieExt.jl:1642
```

### What changed

One line replaces the two that rolled the tag: `tag = "_$(AirfoilAero.delta_suffix(deg2rad(delta))).dat"` — `generated_slices` takes `delta` in degrees, `delta_suffix` in radians. That ends the cause rather than the case: there is now one function naming these files, so a later change to the scheme cannot desynchronise the reader from the writer again.

The warning is rewritten to drop the naming-scheme sentence, which was both wrong and redundant once the listed names are the ones actually looked for, and to name the directory instead — `missing_dats` now holds the path relative to `out_dir` rather than a bare basename, so the message says where it looked. The local was renamed from `missing_deltas`, which described deltas but held `.dat` paths.

The regression test reads the suite's cached `ram_air_matrix_dir` fixture through `generated_slices` at both signs of deflection. It reuses the exact `(n_sections, alpha_range, delta_range)` key the file's existing `ram_air_matrix_wing` call uses, so it shares that generation and adds no NeuralFoil sweep. Before the change the `-1.0` iteration failed all three assertions (the warning fired, `d2.def` was empty, `def3d` was `nothing`) while `+1.0` passed all three — 3 passed, 3 failed; after, 6 passed.

I searched for other hand-built deflection tags before writing (`rg '"_d"'`, `delta_suffix`, `dat_file`): this was the only one. `airfoils/<i>_raw.dat` in `geometry_gen.jl` is the raw-points file and unrelated.

Where I would push back: the test covers the sign case (`m`), not the decimal case (`p`), because a fractional `delta_range` would key a second cached NeuralFoil generation for one extra character of coverage. Both come from the same single `delta_suffix` call, and `write_section_aero`'s own round-trip test already exercises the function.

### Verification

- [x] Reproduced first: the `@warn` above, against unchanged code
- [x] `test/plotting/test_plotting.jl` red before (3 passed, 3 failed), green after (6/6) — juliaserver, test env, `include("plotting/test_plotting.jl")`
- [x] Full plotting file green: `Plotting (Makie)` 58/58 · `Airfoil skin (Makie)` 19/19 · new testset 6/6
- [x] Up to date with `origin/main` (0 behind) · Julia lines ≤ 92 chars
- [x] Local CI mirror (`agent ci-local`, one matrix cell): PASS in 6 min
- [ ] GitHub CI: `Test end-user and developer setup` FAILS, twice on `a9fff16`, for #300 and not for this diff — evidence above. Every other check green.
- [ ] `jetls check`: not run — no `jetls` binary on this box (`bin/jetls` wraps it)
- n/a REUSE lint (repo carries no `REUSE.toml`/`.reuse`) · docs (no new or renamed public symbol; `generated_slices` is already listed in `docs/src/private_functions.md`)
- Risk: the warning now interpolates the full `out_dir` path, so the message is longer than it was. Nothing asserts its text.

### Scope

+26 / -9 across 3 files. `ext/VortexStepMethodMakieExt.jl` is the fix (net −2 lines, including one rewrapped docstring line in the same function); `test/plotting/test_plotting.jl` the regression test; `CHANGELOG.md` one `Fixed` entry. No stack — no open PR touches the extension. Closes #298. Blocked on #300 for a green board.

Closes #298 · task `VortexStepMethod.jl-298`
