### PR TITLE
write_section_aero writes an all-NaN deflected .dat, and read_section_

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@
   `test/solver/solver_test_wing.yaml` wing at 26.6° it stopped 3.6% below `LOOP`'s
   peak circulation and reported `FAILURE`, and now lands on the same distribution
   with a fixed-point residual at machine precision.
+- A deflection the 2D solver returned no contour for is no longer written as an
+  all-`NaN` airfoil `.dat`: `write_section_aero` skips that column, so `isfile` stays
+  the honest test for a generated deflection. `read_section_aero` warns and returns
+  `nothing` for a contour that does not hold its `Cp` table's nodes, where it used to
+  read the `NaN`s back and interpolate a `NaN` airfoil shape at *every* deflection,
+  0° included.
 
 ## VortexStepMethod v5.0.0 2026-09-07
 

--- a/docs/src/private_functions.md
+++ b/docs/src/private_functions.md
@@ -116,7 +116,7 @@ window_alpha
 assemble_polar_matrix
 load_matrix_polar_data
 read_aero_matrix
-read_dat
+read_dat_coordinates
 read_node_table
 write_node_rows
 convert_node_table
@@ -203,7 +203,6 @@ sigmoid
 create_2d_polars
 lei_poly_coeffs
 resolve_airfoil
-read_dat_coordinates
 write_dat
 write_polar_csv
 write_polar_matrix_csv

--- a/src/airfoil_aero/AirfoilAero.jl
+++ b/src/airfoil_aero/AirfoilAero.jl
@@ -9,8 +9,8 @@ using Xfoil
 using Printf: @sprintf
 using ..VortexStepMethod: SectionAero, interpolate_matrix_nans!, delta_suffix,
                           write_node_rows, section_surface, set_polar!,
-                          KulfanParameters, calculate_cl, calculate_cd,
-                          calculate_cm
+                          read_dat_coordinates, KulfanParameters, calculate_cl,
+                          calculate_cd, calculate_cm
 
 include("kulfan.jl")
 include("deform.jl")

--- a/src/airfoil_aero/airfoil_io.jl
+++ b/src/airfoil_aero/airfoil_io.jl
@@ -1,27 +1,4 @@
 """
-    read_dat_coordinates(path) -> (x, y)
-
-Read airfoil coordinates from a Selig-format `.dat` file, skipping header and
-comment lines.
-"""
-function read_dat_coordinates(path::String)
-    x = Float64[]
-    y = Float64[]
-    for line in eachline(path)
-        s = strip(line)
-        (isempty(s) || !(isdigit(s[1]) || s[1] == '-' || s[1] == '.')) && continue
-        parts = split(s)
-        length(parts) >= 2 || continue
-        xp = tryparse(Float64, parts[1])
-        yp = tryparse(Float64, parts[2])
-        (xp === nothing || yp === nothing) && continue
-        push!(x, xp)
-        push!(y, yp)
-    end
-    return x, y
-end
-
-"""
     write_dat(filepath, name, x, y) -> filepath
 
 Write airfoil coordinates to a Selig-format `.dat` file.

--- a/src/airfoil_aero/section_aero_gen.jl
+++ b/src/airfoil_aero/section_aero_gen.jl
@@ -119,7 +119,9 @@ end
 
 Write a [`SectionAero`](@ref) as human-readable files. The airfoil contours share
 `dat_prefix`: `{dat_prefix}.dat` (contour at `delta=0`) plus
-`{dat_prefix}_{delta_suffix(δ)}.dat` per non-zero deflection. The per-node `Cp`/`cf`
+`{dat_prefix}_{delta_suffix(δ)}.dat` per non-zero deflection. A deflection whose
+contour is all `NaN` is skipped, and `{dat_prefix}.dat` falls back to the first
+deflection that has one. The per-node `Cp`/`cf`
 tables share `table_prefix` (defaults to `dat_prefix`): `{table_prefix}_cp.{ext}` and
 `{table_prefix}_cf.{ext}`, where `ext` is `table_format`, either `:csv` (default,
 readable) or `:arrow` (binary, an order of magnitude faster to load). Pass a separate
@@ -134,15 +136,15 @@ function write_section_aero(dat_prefix::AbstractString, aero::SectionAero;
         throw(ArgumentError("table_format must be :csv or :arrow, got :$table_format"))
     mkpath(dirname(dat_prefix))
     mkpath(dirname(table_prefix))
+    finite(jd) = any(isfinite, view(aero.x, :, jd))
     for (jd, d) in enumerate(aero.delta_range)
-        iszero(d) && continue
+        (iszero(d) || !finite(jd)) && continue
         write_dat("$(dat_prefix)_$(delta_suffix(d)).dat", "section",
                   aero.x[:, jd], aero.y[:, jd])
     end
-    # never write `$dat_prefix.dat` all-NaN (read_dat_coordinates would drop it to empty)
-    finite(jd) = any(isfinite, view(aero.x, :, jd))
     jz = findfirst(iszero, aero.delta_range)
-    jdat = jz !== nothing && finite(jz) ? jz : findfirst(finite, eachindex(aero.delta_range))
+    jdat = jz !== nothing && finite(jz) ? jz :
+           findfirst(finite, eachindex(aero.delta_range))
     write_dat("$dat_prefix.dat", "section", aero.x[:, jdat], aero.y[:, jdat])
     cp_path = "$(table_prefix)_cp.$table_format"
     cf_path = "$(table_prefix)_cf.$table_format"

--- a/src/section_aero.jl
+++ b/src/section_aero.jl
@@ -118,21 +118,24 @@ function delta_suffix(delta)
 end
 
 """
-    read_dat(path) -> (x, y)
+    read_dat_coordinates(path) -> (x, y)
 
 Read Selig `.dat` airfoil coordinates (two whitespace-separated columns), skipping the
-name/header line and any non-numeric lines.
+name/header line, comments, and any row that is not a finite pair. The single `.dat`
+reader; [`write_dat`](@ref VortexStepMethod.AirfoilAero.write_dat) is its writer.
 """
-function read_dat(path::AbstractString)
+function read_dat_coordinates(path::AbstractString)
     x = Float64[]
     y = Float64[]
-    for ln in eachline(String(path))
-        p = split(strip(ln))
-        length(p) >= 2 || continue
-        xv, yv = tryparse(Float64, p[1]), tryparse(Float64, p[2])
-        (xv === nothing || yv === nothing) && continue
-        push!(x, xv)
-        push!(y, yv)
+    for line in eachline(String(path))
+        fields = split(strip(line))
+        length(fields) >= 2 || continue
+        xp = tryparse(Float64, fields[1])
+        yp = tryparse(Float64, fields[2])
+        (xp === nothing || yp === nothing) && continue
+        (isfinite(xp) && isfinite(yp)) || continue
+        push!(x, xp)
+        push!(y, yp)
     end
     return x, y
 end
@@ -212,10 +215,11 @@ convert_node_table(src::AbstractString, dst::AbstractString) =
     read_section_aero(dat_file, cp_file, cf_file) -> Union{Nothing, SectionAero}
 
 Assemble a [`SectionAero`](@ref) from the human-readable files: the airfoil contour
-(`dat_file`, plus `{stem}_{delta_suffix(δ)}.dat` per non-zero deflection) and the per-node `Cp`
-and `cf` tables in the `.dat` node order, CSV or Arrow as their suffix says (see
-[`read_node_table`](@ref)). Returns `nothing` if any file is missing. This is the single
-loader for both provided and generated aero.
+(`dat_file`, plus `{stem}_{delta_suffix(δ)}.dat` per non-zero deflection) and the
+per-node `Cp` and `cf` tables in the `.dat` node order, CSV or Arrow as their suffix
+says (see [`read_node_table`](@ref)). Returns `nothing` if one of the three named files
+is missing, and `nothing` with a warning if a contour does not hold exactly the tables'
+nodes. This is the single loader for both provided and generated aero.
 """
 function read_section_aero(dat_file::AbstractString, cp_file::AbstractString,
                            cf_file::AbstractString)
@@ -229,8 +233,13 @@ function read_section_aero(dat_file::AbstractString, cp_file::AbstractString,
     x = fill(NaN, n_node, length(delta_range))
     y = fill(NaN, n_node, length(delta_range))
     for (jd, d) in enumerate(delta_range)
-        xd, yd = read_dat(iszero(d) ? String(dat_file) :
-                          "$(stem)_$(delta_suffix(d)).dat")
+        contour = iszero(d) ? String(dat_file) : "$(stem)_$(delta_suffix(d)).dat"
+        xd, yd = isfile(contour) ? read_dat_coordinates(contour) : (Float64[], Float64[])
+        if length(xd) != n_node
+            @warn "$contour holds $(length(xd)) finite coordinates, not the $n_node " *
+                  "nodes of its Cp table; this airfoil gets no surface aero."
+            return nothing
+        end
         x[:, jd] .= xd
         y[:, jd] .= yd
     end

--- a/test/airfoil_aero/test_airfoil_aero.jl
+++ b/test/airfoil_aero/test_airfoil_aero.jl
@@ -285,7 +285,7 @@ end
 end
 
 @testset "generate_airfoils fits the wrapped contour it is handed" begin
-    x_raw, y_raw = read_dat_coords(joinpath(@__DIR__, "data", "test_airfoil.dat"))
+    x_raw, y_raw = read_dat_coordinates(joinpath(@__DIR__, "data", "test_airfoil.dat"))
     x_fit, y_fit = shrink_wrap(x_raw, y_raw, ShrinkWrap(clearance=0.0))
     _, fitted_y = kulfan_to_coordinates(
         fit_kulfan_parameters(x_fit, y_fit, LeastSquaresFit()))
@@ -294,7 +294,7 @@ end
         Re=5e5, alpha_range=-2:2:2,
         aero_solver=NeuralFoilSolver(model_size="medium"), verbose=false)
     @test ok == [1]
-    _, written_y = read_dat_coords(joinpath(out, "airfoils", "1.dat"))
+    _, written_y = read_dat_coordinates(joinpath(out, "airfoils", "1.dat"))
     # A second shrink wrap inflates the section by its clearance, 0.006 — 60x this bound.
     @test maximum(abs, collect(extrema(written_y)) .-
                        collect(extrema(fitted_y))) < 1e-4

--- a/test/airfoil_aero/test_airfoil_aero.jl
+++ b/test/airfoil_aero/test_airfoil_aero.jl
@@ -14,17 +14,6 @@ seg_dist(px, py, ax, ay, bx, by) = begin
     hypot(px - (ax + t * vx), py - (ay + t * vy))
 end
 
-read_dat_coords(path) = begin
-    x = Float64[]; y = Float64[]
-    for ln in eachline(path)
-        s = strip(ln)
-        (isempty(s) || !(isdigit(s[1]) || s[1] == '-' || s[1] == '.')) && continue
-        p = split(s); length(p) >= 2 || continue
-        push!(x, parse(Float64, p[1])); push!(y, parse(Float64, p[2]))
-    end
-    x, y
-end
-
 @testset "Kulfan fit and NeuralFoil" begin
     @testset "Round-trip recovers known parameters" begin
         truth = KulfanParameters(fill(0.2, 8), fill(-0.2, 8), 0.0, 0.0)
@@ -37,7 +26,7 @@ end
     end
 
     dat = joinpath(@__DIR__, "data", "test_airfoil.dat")
-    xr, yr = read_dat_coords(dat)
+    xr, yr = read_dat_coordinates(dat)
     params = fit_kulfan_parameters(xr, yr)
 
     @testset "Fit matches aerosandbox get_kulfan_parameters" begin
@@ -165,6 +154,29 @@ end
     @test_throws ArgumentError write_section_aero(prefix, aero; table_format=:parquet)
 end
 
+@testset "a deflection with no contour is neither written nor loaded as NaN" begin
+    alpha_range = deg2rad.([-5.0, 0.0, 5.0])
+    delta_range = deg2rad.([0.0, 1.0])
+    xc = [1.0, 0.5, 0.0, 0.5, 1.0]
+    yc = [0.0, 0.06, 0.0, -0.04, 0.0]
+    n_node = length(xc)
+    cp = [float(100i + 10ia + jd) for i in 1:n_node,
+          ia in eachindex(alpha_range), jd in eachindex(delta_range)]
+    aero = SectionAero(alpha_range, delta_range, hcat(xc, fill(NaN, n_node)),
+                       hcat(yc, fill(NaN, n_node)), cp, cp ./ 1000)
+
+    prefix = joinpath(mktempdir(), "af")
+    dat, cp_csv, cf_csv = write_section_aero(prefix, aero)
+    deflected = "$(prefix)_d1.dat"
+    @test !isfile(deflected)
+    @test isapprox(first(read_dat_coordinates(dat)), xc; atol=1e-6)
+    @test (@test_logs (:warn,) read_section_aero(dat, cp_csv, cf_csv)) === nothing
+
+    write_dat(deflected, "section", fill(NaN, n_node), fill(NaN, n_node))
+    @test isempty(first(read_dat_coordinates(deflected)))
+    @test (@test_logs (:warn,) read_section_aero(dat, cp_csv, cf_csv)) === nothing
+end
+
 @testset "generate_section_aero builds a surface table" begin
     truth = KulfanParameters(fill(0.15, 8), fill(-0.15, 8), 0.1, 0.0)
     alpha_range = deg2rad.(-4.0:2.0:4.0)
@@ -181,7 +193,7 @@ end
     _, _, cp_hi_a, _ = section_surface(aero, alpha_range[end], delta_range[1])
     @test maximum(abs.(cp_lo_a .- cp_hi_a)) > 0.1
 
-    xdat, ydat = read_dat_coords(joinpath(@__DIR__, "data", "test_airfoil.dat"))
+    xdat, ydat = read_dat_coordinates(joinpath(@__DIR__, "data", "test_airfoil.dat"))
     aero2 = generate_section_aero(NeuralFoilSolver(model_size="medium"), xdat, ydat;
         alpha_range, delta_range=deg2rad.([0.0, 5.0]), reynolds_number=5e5)
     @test aero2 isa SectionAero
@@ -237,7 +249,7 @@ end
 end
 
 @testset "generate_polar_from_coordinates POLAR_VECTORS sweep" begin
-    x, y = read_dat_coords(joinpath(@__DIR__, "data", "test_airfoil.dat"))
+    x, y = read_dat_coordinates(joinpath(@__DIR__, "data", "test_airfoil.dat"))
     csv = joinpath(mktempdir(), "polar.csv")
     sols = generate_polar_from_coordinates(x, y, csv;
         Re=5e5, alpha_range=-4:2:4, solver=NeuralFoilSolver(model_size="medium"))
@@ -249,7 +261,7 @@ end
 end
 
 @testset "turn_trailing_edge! legacy crease cleanup" begin
-    x, y = read_dat_coords(joinpath(@__DIR__, "data", "test_airfoil.dat"))
+    x, y = read_dat_coordinates(joinpath(@__DIR__, "data", "test_airfoil.dat"))
     crease_frac = 0.7
     for angle in (deg2rad(10.0), deg2rad(-10.0))
         xd, yd = collect(float.(x)), collect(float.(y))


### PR DESCRIPTION
### TL;DR

`write_section_aero` no longer writes a deflection whose contour is all `NaN`, and the two `.dat` readers that disagreed about `NaN` rows are now one strict reader. A deflection the 2D solver converged at no angle used to reach a loaded `Wing` as a `NaN` airfoil shape at **every** deflection, 0° included, with no error and no warning.

### What was wrong

`generate_airfoil_aero` writes a contour column only from a solution whose node count matches the grid's modal one, and `XFoilSolver` returns empty node arrays for a non-converged angle — so a deflection that converged nowhere leaves `x[:, jd]` and `y[:, jd]` at their `fill(NaN, …)` initial value. `write_section_aero` wrote that column out as `airfoils/<id>_d<tag>.dat` full of `NaN NaN` rows, three lines above a guard whose comment already names the hazard for `{dat_prefix}.dat`.

Then the readers disagreed. `read_dat_coordinates` (submodule) kept only rows starting with a digit, `-` or `.`, so an all-`NaN` file read back as zero points and its caller crashed — that is the CI failure on #299, `argmin` on an empty `x` inside `normalize_airfoil`. `read_dat` (main package) had no such filter and `tryparse(Float64, "NaN")` succeeds, so `read_section_aero` got a full-length `NaN` vector, the lengths matched, and the `NaN`s landed in `x_interp`/`y_interp`. Linear interpolation between a finite node and a `NaN` node is `NaN` everywhere, which is why the contour came out `NaN` at 0° as well. Ten lines reproduce it with no solver at all, a `SectionAero` whose 1° column is `NaN`:

```
wrote _d1.dat: isfile=true
section | NaN NaN | NaN NaN
read_dat_coordinates: 0 points
read_section_aero: SectionAero{…}
  contour at delta=0.0: x=[NaN, NaN, NaN, NaN, NaN]
  contour at delta=1.0: x=[NaN, NaN, NaN, NaN, NaN]
```

### What I changed

`write_section_aero` hoists the `finite(jd)` helper it already had above the deflection loop and skips a column with no finite contour, so no all-`NaN` `.dat` is ever written and `isfile` stays the honest test for a generated deflection — which is what the Makie audit plot already assumes, warning and drawing nothing for a deflection it finds no file for.

The duplicate reader is gone rather than aligned. `read_dat_coordinates` moves into `src/section_aero.jl` beside `read_node_table` and `read_section_aero`, since loading lives in the main package and writing in `AirfoilAero`; `AirfoilAero` imports and re-exports it, so every existing caller and the `using VortexStepMethod.AirfoilAero: read_dat_coordinates` in the tests are unchanged. It now drops a row by value (`isfinite`) instead of by first character, which is what the first-character filter was approximating: that filter skipped `NaN NaN` only because `N` is not a digit, and let `0.5 NaN` through. I searched for further copies before deleting the second one and found a third — `read_dat_coords` in `test/airfoil_aero/test_airfoil_aero.jl`, a test-local reader of the same format — and deleted it too, in the file this PR already changes.

`read_section_aero` is the last link: a deflected contour that is missing, or that does not hold exactly its `Cp` table's node count, now warns and returns `nothing` instead of quietly filling the interpolants. `nothing` is a state the loader already returns and `add_section!` already takes, so an airfoil with a broken contour set loses its surface aero and keeps its polar, rather than poisoning the whole wing's geometry.

### The third item, and a better fix underneath it

Should `generate_airfoils` fail an id outright when a deflection converged at no angle, the way `all(isnan, clvals)` already fails one for column 1? I would, and for the same reason: the coefficients of such a column survive only because `fill_node_nans!` interpolated them from the neighbouring deflections, so what the id offers at that delta is a fabricated polar and, after this PR, no surface data at all. `reuse_valid_airfoils=true` then maps those sections to the nearest id that solved everywhere — a visible, documented degradation — and `reuse_valid_airfoils=false` errors, which is what a caller who turned the fallback off asked to hear. The push-back is that it costs a whole airfoil for one fussy deflection, and #291 says that fixture's convergence moves between runs.

There is a cheaper fix underneath it that I would rather see: the contour does not depend on the solver converging at all. It is `deform_section`'s own output, handed *in*, and `NeuralFoilSolver` already carries it straight through (`s.x = def.x`). I measured what XFoil gives back at `repanel=false` — 239 nodes against `def`'s 239, `max|dx| = max|dy| = 0.0` at both 0° and 3° — so `generate_airfoil_aero` could take `x`/`y` from `def` whenever its node count matches the modal one and no geometry column would ever be `NaN`, for either backend. That does not subsume this PR: a converged deflection whose node count is not the modal one still leaves a `NaN` column, so the writer's guard stays the backstop. Say the word and I will open it as its own task.

This is the fix for the red `Test end-user and developer setup` check that #299 carried, and that check is green here: with no all-`NaN` `_d1.dat` written, `generated_slices` takes its `isfile` branch and warns instead of crashing in `normalize_airfoil`. #295 names the same guard but is about a degenerate *finite* fit, and neither fix covers the other.

### The one red job is not this diff

`Julia 1.12 - windows-latest - x64` on `5e78ab6` is #287's flake, and `main` settles it rather than my say-so: twenty minutes after this run, `main`'s own push CI for the #308 merge ([run 34696079829](https://github.com/OpenSourceAWE/VortexStepMethod.jl/actions/runs/34696079829)) failed the identical assertion in `Julia 1.12 - ubuntu` at `relative_error(jac_fd, jac_fwd) = 0.0420681631196805`, against this branch's `0.04206403446037785` at `test/solver/test_forwarddiff.jl:87`. Same test, same ~0.042 branch of the bimodal jump #287 records, on a commit carrying none of these seven files. Which cell fires moves run to run and OS to OS: windows red and 1.12 ubuntu green here, 1.12 ubuntu red and windows green on `main`, and on the earlier `3c4fd7e` both 1.12 ubuntu cells at 0.03999947 and 0.04001102 with windows green. It is a bug in the test — a 1e-4 bound over a discrete interpolant jump — and #287 owns it.

So the failing check is not evidence about this diff, and I ruled the diff out by measurement rather than by argument. `test_forwarddiff` builds its wing from a generated directory, which does go through the reader this PR rewrites, so I deleted that fixture and regenerated it through this branch's writer: 16 `.dat` files, **not one with a `NaN` row**, and the strict reader returns coordinates identical to the lenient one it replaces on **all 16**. The change cannot alter what that test loads. On that fresh fixture the file is 7/7 green with `norm(jac_fwd) = 3.2971127281317214` and `rel_err = 5.22e-8` — 1900x inside the bound, and 800000x below what CI saw.

### Merging `main` in

`main` has since taken #294, #299, #306, #310 and #312, and v5.1.0 went out. Only `CHANGELOG.md` conflicted, both sides having added to the same `### Fixed` block: my entry moves to `## Unreleased`, where it belongs now that v5.1.0 shipped without it, and both of `main`'s entries stay verbatim.

One conflict was semantic and the textual merge hid it. #294 added `@testset "generate_airfoils fits the wrapped contour it is handed"` at the end of `test/airfoil_aero/test_airfoil_aero.jl`, and it calls `read_dat_coords` — the test-local third reader this PR deletes. The merged file was clean to `git` and `UndefVarError` to Julia. Both calls now go through `read_dat_coordinates`, which is the point of the deletion; the two files it reads are finite, so the strict reader returns the same coordinates.

`main`'s #312 guards the other end of the same bug — the audit plot skipping a deflected `.dat` that reads back empty — and the two do not overlap: #312 protects a directory already generated with an all-`NaN` `.dat`, this stops one being written. Its "Audit slices (Makie)" testset writes its blank file by hand, so it still exercises that guard with this writer in place, and passes 7/7 here.

### Verification

- [x] Reproduced first: `contour at delta=0.0: x=[NaN, NaN, NaN, NaN, NaN]` from a `SectionAero` whose only bad column is 1°, written and read back through the public writer and loader
- [x] `test/airfoil_aero/test_airfoil_aero.jl` — new testset "a deflection with no contour is neither written nor loaded as NaN" 2 passed / 3 failed before the change (the `.dat` was written, the load returned a `SectionAero`), 7/7 after
- [x] Re-run against the merged tree (juliaserver, examples env): `airfoil_aero/test_airfoil_aero.jl` (87 over 11 testsets, #294's new one among them at 2/2 and this PR's at 7/7), `airfoil_aero/test_live_polar.jl` (93), `obj_adapter/test_obj_adapter.jl` (52, the generate → `Wing(yaml)` round trip), `solver/test_backend_comparison.jl` (15), `yaml_geometry/test_yaml_geometry.jl` (178), `plotting/test_plotting.jl` (58 + 19 + #312's 6 and 7, the other caller of the moved reader), `Aqua.jl` (10) — no failures
- [x] Docs build clean against the merged tree (`docs/make.jl`, only the pre-existing `size_threshold_warn` notices on `private_functions.md` and `functions.md`) · REUSE: n/a, no `bin/reuse_lint` · merged up to `origin/main` (`8b0c6bc`)
- [x] GitHub CI on `5e78ab6`: six of seven checks green — Documentation, `Julia 1.11 - ubuntu`, `Julia 1.12 - ubuntu`, `Julia 1.12 - macOS-aarch64`, codecov/patch and `Test end-user and developer setup`. `Julia 1.12 - windows` red on #287's flake alone (`0.04206403446037785`), with this PR's testset 7/7 inside it, and `main` red on that same assertion at `0.0420681631196805` twenty minutes later. Local CI mirror (`agent ci-local`, one matrix cell) on the merged tree: PASS in 13m
- [x] `test/solver/test_forwarddiff.jl` on this branch, fixture deleted and regenerated through the new writer: 7/7 green, `norm(jac_fwd) = 3.2971127281317214`, `rel_err = 5.22e-8` against the 1e-4 bound (juliaserver, examples env)
- [x] Every `test/generated/` fixture deleted and rebuilt through this branch's writer, then the two suites that consume them re-run, because the copies my earlier runs used were written before this branch took #294: `obj_adapter/test_obj_adapter.jl` 52/52 and `plotting/test_plotting.jl` 58 + 19 + 6 + 7 — same counts as against the cached fixtures, so nothing in this PR's evidence rested on the stale contour
- Risk: `read_section_aero` returning `nothing` where it used to throw a `SystemError` for a deflected contour it cannot open. Every generated directory on disk today with an all-`NaN` `_d1.dat` now warns and loads without surface aero instead of loading a `NaN` one, which is the intent — but a hand-made directory whose deflection tag does not match `delta_suffix` degrades where it used to fail loudly.

### Scope

+70 / −65 across 7 files against the merge base (`8b0c6bc`), of which 20 deleted lines are the two duplicate `.dat` readers and 23 are the moved one. No stack.

Found on the way, not fixed here: `test/generated/`'s fixture path is keyed on `hash((n_sections, alpha_range, delta_range))` and nothing about the code that fills it (`test/test_data_utils.jl:46-49`), so a box whose cache predates a contour-generation change keeps testing the old contour. It cost me a wrong number: my first `test_forwarddiff` run on this merged tree reported `norm(jac_fwd) = 2.2059`, #294's pre-fix doubly-wrapped value, from a directory generated the day before; regenerating gave `3.29711`. CI never sees it, checking out fresh each run. Keying the path on the generator's version, or stamping the config into the directory, is a change to shared test infrastructure that no test here needs — its own task, and worth one to whoever picks up #287, whose next step is reproducing that fixture.

Also found, not fixed: `test/test_body_aerodynamics.jl`, `test/test_solver.jl` and `test/test_yaml_geometry.jl` are tracked and zero bytes — leftovers of the move into `test/<area>/`, which nothing includes. `include`ing one silently does nothing, which is how I met them. Three file deletions in a diff that has no other reason to open them is a `cleanup:` PR; say the word and I will open it.

Closes #300 · task `VortexStepMethod.jl-300`
