### PR TITLE
Release VortexStepMethod v5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## VortexStepMethod v5.1.0 2026-09-11
 
 ### Added
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "VortexStepMethod"
 uuid = "ed3cd733-9f0f-46a9-93e0-89b8d4998dd9"
 authors = ["1-Bart-1 <bart@vandelint.net>", "Oriol Cayon and contributors"]
-version = "5.0.0"
+version = "5.1.0"
 
 [workspace]
 projects = ["examples", "docs", "test"]


### PR DESCRIPTION
`version` in `Project.toml` and the `## Unreleased` header in `CHANGELOG.md`, and nothing else.

Merging this is the approval to register the release: `bin/release` runs against this branch's merge on the default branch, and refuses a version the changelog's top header does not match.