### PR TITLE
Tests on main are failing

### DIFF
--- a/test/solver/test_forwarddiff.jl
+++ b/test/solver/test_forwarddiff.jl
@@ -80,7 +80,7 @@ using Test
             ram_solver, ram_body, y_op;
             theta_idxs=1:4, va_idxs=5:7, omega_idxs=8:10,
             aero_coeffs=true,
-            # A wider step lets the secant span a knot of the polar's 5° alpha grid.
+            # 1e-8 keeps the secant inside one cell of the polar's 5° alpha grid.
             backend=AutoFiniteDiff(absstep=1e-8, relstep=1e-8))
         @test conv_fd
 


### PR DESCRIPTION
### TL;DR

Tests on `main` are red because the `POLAR_MATRICES` forwarddiff check in `test/solver/test_forwarddiff.jl` flakes when a finite-difference step spans a knot of the polar's 5° alpha grid. #292 carries the fix; this PR sits on top of it and clears the advisory review's one comment, the misleading step-width comment.

### What is failing and why

`main` CI failed the "AutoForwardDiff matches AutoFiniteDiff (LOOP, POLAR_MATRICES)" testset twice with the identical assertion: `Expression: rel_err < 0.001` / `Evaluated: 0.04001429189872729 < 0.001` at `test/solver/test_forwarddiff.jl:88` — run 34446797250 (the merge of #285) and again on release PR #302 (run 34628824540). Nothing else on `main` failed.

The check differentiates a piecewise-linear polar whose alpha grid has knots every 5°, and a 1e-5 forward-difference step straddling a knot measures the average of two slopes while forward AD takes one. Whether a panel's converged alpha lands inside that window is decided by the NeuralFoil fixture, which is redrawn every CI run (#291) — that is the #287 flake, and the recorded failure value matches #292's knot-bisection exactly.

### What changed

#292 (the base of this stack) fixes the flake in `test/solver/test_forwarddiff.jl` only: `rtol` 1e-7→1e-11 so the converged panel alpha stops wobbling, the finite-difference step 1e-5→1e-8 so the secant stays inside one polar cell, and the bound 1e-3→1e-4 — a tightening, not a loosening. Its CI is green.

This PR is the one commit on top: #292's advisory review flagged the added comment at line 83, which described the old wide step next to the new narrow one and could invert the intent for the next reader. Reworded to say what is true: `# 1e-8 keeps the secant inside one cell of the polar's 5° alpha grid.` The test result is untouched.

Left alone: the fixture-reproducibility root cause is #291, and the release is #302 — neither belongs to this stack.

### Verification

- [x] Reproduced first: `main` CI run 34446797250 and release #302 run 34628824540 both fail `rel_err < 0.001` / `Evaluated: 0.04001429189872729 < 0.001` at `test/solver/test_forwarddiff.jl:88`
- [x] `test/solver/test_forwarddiff.jl` green on the stacked branch (juliaserver, `test` env, 7/7) and green on unpatched `main` locally (7/7 — the flake only bites on a fresh fixture draw, so the recorded CI value is the reproduction)
- [x] Local full suite: `agent ci-local` running · GitHub CI: pending PR open
- [x] Docs build: n/a — no public symbol touched · REUSE lint: repo carries no REUSE · up to date with the stack base
- Benchmark: n/a — test-only change
- Risk: none for the comment reword; the flake fix's residual risk is stated in #292 (forward AD and a forward difference must agree on the side of the corner when the panel lands exactly on a knot)

### Scope

+1 / −1 in `test/solver/test_forwarddiff.jl` and nothing else. Stack: 2/2 → #292.

Closes #303 · task `VortexStepMethod.jl-303`
