### PR TITLE
bin/release: the version check scans every `## ` header, so an `## Unreleased` section makes it re-register the last release

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -53,7 +53,7 @@ if [[ -z "$_version" ]]; then
     exit 1
 fi
 
-_changelog_version=$(awk '/^## / {for (i = 1; i <= NF; i++) if ($i ~ /^v[0-9]/) {print $i; exit}}' CHANGELOG.md)
+_changelog_version=$(awk '/^## / {for (i = 1; i <= NF; i++) if ($i ~ /^v[0-9]/) print $i; exit}' CHANGELOG.md)
 if [[ "$_changelog_version" != "v$_version" ]]; then
     echo "Version mismatch: Project.toml is $_version but CHANGELOG top is" \
          "$_changelog_version (expected v$_version)." >&2

--- a/test/bin/test_release.jl
+++ b/test/bin/test_release.jl
@@ -1,0 +1,70 @@
+using Test
+
+"""
+    dry_run_release(top_header, older_header) -> (exit_code, stderr_text)
+
+Run `bin/release --dry-run` against a throwaway repository at version 5.0.0
+whose `CHANGELOG.md` holds a section under each of the two headers, with a stub
+`gh` on `PATH` so nothing reaches GitHub.
+"""
+function dry_run_release(top_header, older_header)
+    root = mktempdir()
+    repo = mkpath(joinpath(root, "repo"))
+    write(joinpath(repo, "Project.toml"), """
+        name = "Fixture"
+        version = "5.0.0"
+        """)
+    write(joinpath(repo, "CHANGELOG.md"), """
+        # Changelog
+
+        $top_header
+
+        ### Added
+
+        - the newer note
+
+        $older_header
+
+        ### Fixed
+
+        - the older note
+        """)
+    run(`git -C $repo init --quiet`)
+    run(`git -C $repo add --all`)
+    run(`git -C $repo -c user.email=fixture@example.com -c user.name=Fixture
+         commit --quiet -m "fixture"`)
+
+    stub = mkpath(joinpath(root, "stub"))
+    gh_stub = joinpath(stub, "gh")
+    write(gh_stub, """
+        #!/bin/bash
+        case "\$1" in
+            repo) echo "OpenSourceAWE/Fixture" ;;
+        esac
+        """)
+    chmod(gh_stub, 0o755)
+
+    script = normpath(joinpath(@__DIR__, "..", "..", "bin", "release"))
+    stderr_file = joinpath(root, "stderr.txt")
+    env = copy(ENV)
+    env["PATH"] = stub * ":" * ENV["PATH"]
+    command = setenv(`bash $script --dry-run`, env; dir=repo)
+    process = run(pipeline(ignorestatus(command); stdout=devnull, stderr=stderr_file))
+    return process.exitcode, read(stderr_file, String)
+end
+
+@testset "bin/release" begin
+    @testset "release refuses an unversioned top section above the last release" begin
+        exit_code, stderr_text =
+            dry_run_release("## Unreleased", "## Fixture v5.0.0 2026-09-07")
+        @test exit_code != 0
+        @test occursin("Version mismatch", stderr_text)
+    end
+
+    @testset "release accepts a top section naming the package version" begin
+        exit_code, stderr_text =
+            dry_run_release("## Fixture v5.0.0 2026-09-07", "## Fixture v4.3.1 2026-08-01")
+        @test exit_code == 0
+        @test isempty(stderr_text)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,6 +65,8 @@ function include_selected_tests()
     should_run_test("airfoil_aero/test_live_polar.jl") && include("airfoil_aero/test_live_polar.jl")
     should_run_test("obj_adapter/test_obj_adapter.jl") && include("obj_adapter/test_obj_adapter.jl")
     should_run_test("surfplan/test_surfplan.jl") && include("surfplan/test_surfplan.jl")
+    # bin/release is a bash script, so only the unix runners can run it.
+    Sys.isunix() && should_run_test("bin/test_release.jl") && include("bin/test_release.jl")
     should_run_test("Aqua.jl") && include("Aqua.jl")
 end
 


### PR DESCRIPTION
### TL;DR

`bin/release` read the changelog version with an awk scan that only stopped once it had found a `v[0-9]` field, so a top section without one — `## Unreleased` — fell through to the next `## ` header and returned the previous release. The `exit` now fires on the first `## ` line whatever it holds, so an unversioned top header yields an empty version and the guard refuses.

### What it did on this tree

`main` at `fb1eea7` carried `version = "5.0.0"` in `Project.toml` and `## Unreleased` above the `## VortexStepMethod v5.0.0 2026-09-07` section, which is exactly the shape that defeats the scan — the fallthrough finds `v5.0.0`, it matches `Project.toml`, and the guard passes:

```
$ ./bin/release --dry-run
Repository:   OpenSourceAWE/VortexStepMethod.jl
Version:      v5.0.0
Commit:       fb1eea7d9965980b0893dbc8d90e6bbc6f57788c

Release notes:
### Added
- `solve!(...; throw_on_fail=true)` throws a `SolveFailure` ...
### Fixed
- The `NONLIN` solver backtracks along each Newton step ...
exit=0
```

That is a run of `./bin/release` posting its registration comment for v5.0.0 — already tagged and registered — carrying the notes of the version that has not gone out yet. The same tree after the fix:

```
$ ./bin/release --dry-run
Version mismatch: Project.toml is 5.0.0 but CHANGELOG top is  (expected v5.0.0).
Update CHANGELOG.md so its first '## ' header matches the package version.
exit=1
```

The message the guard already prints — "Update CHANGELOG.md so its first `## ` header matches the package version" — is what the scan was supposed to be checking, so this is the code catching up with its own error message rather than a new rule. The empty slot it leaves in that first line ("CHANGELOG top is  (expected ...)") reads a little bare; I left it alone rather than add a branch for the no-version case, since the sentence still says the true thing.

### The test

`test/bin/test_release.jl` builds a throwaway repository — `Project.toml` at 5.0.0, a two-section `CHANGELOG.md`, `git init` and a commit, a stub `gh` first on `PATH` so nothing reaches GitHub — and runs `bash bin/release --dry-run` in it.

The fixture has to put the *package's own version* in the second section for the bug to bite: a first draft with `v4.3.1` down there passed against the unfixed script, because the fallthrough then returned a version that mismatched anyway. The test that reproduces is the pair `## Unreleased` over `## Fixture v5.0.0`, asserting a non-zero exit and `Version mismatch` on stderr; the second testset is the control, a top header naming the package version, which must still exit 0 with nothing on stderr — without it the first would pass on any failure at all, `gh` not being installed included.

It is registered under `Sys.isunix()` in `test/runtests.jl`: the script is bash, and the Windows runner in the matrix has no business running it.

No `CHANGELOG.md` entry. `bin/install` and `bin/run_julia` changes are logged there because users run them; `bin/release` is the maintainer's, and its top section is what #302 is turning into v5.1.0 right now — a bullet from me would land in the middle of a release in flight for a line no package user reads. Say the word and I will add one.

### Why there is a `Register Failed` comment on this thread

JuliaRegistrator answered this pull request [here](https://github.com/OpenSourceAWE/VortexStepMethod.jl/pull/305#issuecomment-5639662613). Describing what `bin/release` posts meant writing the trigger phrase, and backticks do not hide it from the bot — it reads the PR body, found the phrase, and tried to register. It failed only because the author's org membership is not public. So the phrase must not appear in any comment or PR body on this repo, and nothing above spells it out. Worth knowing while #302 is in flight: it is the same accident this issue is about, arriving by a different door.

### The red check is #300, not this branch

`Test end-user and developer setup` is red on `ea6680877` ([34645746964](https://github.com/OpenSourceAWE/VortexStepMethod.jl/actions/runs/34645746964)). It is `ArgumentError: reducing over an empty collection` at `src/airfoil_aero/kulfan.jl:71` — `argmin` on an empty `x` — through `fit_kulfan_parameters` → `generated_slices` → `plot_slices_3d` from `examples/ram_air_kite.jl:79`, ending the job at `run_all failed for 1 example(s): ram_air_kite.jl`, 15 passed / 1 failed. That is #300 down to the same stacktrace, already written up there and with the fix open as #301: `write_section_aero` writes an all-NaN `_d1.dat`, `read_dat_coordinates` drops every `NaN NaN` row, and the reader hands `fit_kulfan_parameters` nothing.

Nothing on this branch can reach it — the diff is `bin/release`, a new test file and one line of `test/runtests.jl`, none of which the setup workflow's examples touch. It is landing on whatever is in the queue: #306's branch, whose diff is solver code only, failed the same job with the identical signature nine minutes before mine ([34645270956](https://github.com/OpenSourceAWE/VortexStepMethod.jl/actions/runs/34645270956)) and passed it an hour earlier ([34639515312](https://github.com/OpenSourceAWE/VortexStepMethod.jl/actions/runs/34639515312)); `release/v5.1.0` ([34628824619](https://github.com/OpenSourceAWE/VortexStepMethod.jl/actions/runs/34628824619)) and #292's branch ([34637447090](https://github.com/OpenSourceAWE/VortexStepMethod.jl/actions/runs/34637447090)) failed it too. Which XFoil deflections converge moves run to run — #300's own finding, and #291's. It is not falling my way, though: the previous commit `0524692` hit it on both attempts of its run, and the merge of `main` has now hit it again.

No new issue: #300 has it, with more detail than I could add.

### Verification

- [x] Reproduced first: `./bin/release --dry-run` on `fb1eea7` printed `Version: v5.0.0` with the Unreleased notes and exited 0
- [x] `test/bin/test_release.jl` red before, green after (juliaserver): before, "refuses an unversioned top section" failed 2/2 while the control passed 2/2; after, 4/4 pass — re-run on the merged head `ea66808`, still 4/4
- [x] `test/runtests.jl bin/test_release.jl` through the suite runner: 4/4 PASS
- [x] Local full suite on `0524692`: PASS (7 min, Julia 1.12.7, one matrix cell) — the `agent:ci-local` comment on the thread. **Not re-run on the merged head**: the box killed it twice for memory with other agents on it, and GitHub CI covers `ea66808` on seven cells, so I left the box alone rather than take a third run
- [ ] GitHub CI on `ea66808`: all seven cells of [34645746941](https://github.com/OpenSourceAWE/VortexStepMethod.jl/actions/runs/34645746941) green — Documentation, 1.12 macOS/ubuntu/windows, 1.11 ubuntu, and both coverage jobs — plus `codecov/patch`. `Test end-user and developer setup` red on `kulfan.jl:71` — #300, as above
- [x] No new public symbols, so no docs page · no REUSE setup in this repo
- [x] Merged `origin/main` (`ea66808`); no conflict — main's side is `src/solver.jl`, `src/settings.jl`, `CHANGELOG.md` and test files, none of them this branch's
- Benchmark: n/a
- Risk: the fixture's stub `gh` answers only `gh repo view`; a future `bin/release` that shells out to `gh` for something new before the version guard would make the control testset fail rather than the case it is guarding.

### Scope

+73 / -1 across 3 files, of which 70 lines are the new test. `bin/release` is one line: the `exit` moves out of the `if`. Not stacked — #302 touches only `CHANGELOG.md` and `Project.toml`. CI.yml's `fail-fast: false` (gate item 10) is #279's, already queued.

Closes #280 · task `VortexStepMethod.jl-280`
