### PR TITLE
docs: the settings file has no reference page — `mesh:` and `airfoil:` are reachable only through docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Three kinds of input data is needed:
 
 Wing geometry can also be loaded from YAML files or `.obj` files. See the examples for details.
 
+A whole run — the flight condition, each wing and the solver — is configured by a `vsm_settings.yaml`. See [The settings file](https://OpenSourceAWE.github.io/VortexStepMethod.jl/dev/settings/) for an annotated example.
+
 ### Example for defining the required input:
 ```julia
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,6 +19,7 @@ makedocs(;
         "Home" => "index.md",
         "How it works" => "explanation.md",
         "CAD mesh to model" => "airfoil_pipeline.md",
+        "Settings file" => "settings.md",
         "Examples" => "examples.md",
         "Exported Functions" => "functions.md",
         "Exported Types" => "types.md",

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -102,6 +102,8 @@ Three kinds of input data is needed:
 
 Wing geometry can also be loaded from YAML files or `.obj` files. See the examples for details.
 
+A whole run — the flight condition, each wing and the solver — is configured by a `vsm_settings.yaml`. See [The settings file](@ref) for an annotated example.
+
 ### Example for defining the required input:
 
 ```julia

--- a/docs/src/settings.md
+++ b/docs/src/settings.md
@@ -1,0 +1,114 @@
+# The settings file
+
+A `vsm_settings.yaml` configures a whole run in one place: the flight condition, each
+wing and how it is discretised, and the numerical solver. [`VSMSettings`](@ref) reads
+it, and [`Wing`](@ref), [`Solver`](@ref) and [`set_va!`](@ref) are each built from the
+object it returns.
+
+```julia
+settings = VSMSettings("ram_air_kite/vsm_settings.yaml")           # under data/
+settings = VSMSettings("my/vsm_settings.yaml"; data_prefix=false)  # as written
+
+wing = Wing(settings)
+body_aero = BodyAerodynamics([wing])
+solver = Solver(body_aero, settings)
+set_va!(body_aero, settings)
+```
+
+The file has three top-level blocks — `condition:`, `wings:` and `solver_settings:` —
+and each may be left out, in which case its defaults apply. `wings:` is a list, so a
+multi-wing configuration repeats the entry.
+
+## An annotated file
+
+Every key below is optional except a wing's `name`, `n_panels`,
+`spanwise_panel_distribution`, `spanwise_direction` and `remove_nan`, and — whenever
+`solver_settings:` is present — its `aerodynamic_model_type` and
+`type_initial_gamma_distribution`. An omitted key keeps its default: the `condition:`
+values shown are those defaults, and the docstrings linked below carry the rest.
+
+```yaml
+condition:
+  wind_speed: 10.0                # free-stream velocity magnitude [m/s]
+  alpha: 5.0                      # angle of attack [°]
+  beta: 0.0                       # sideslip angle [°]
+  yaw_rate: 0.0                   # yaw rate [°/s]
+
+wings:
+  - name: main_wing               # label the wing carries into plots and output
+    # sections and polars, resolved against the working directory
+    geometry_file: data/ram_air_kite/geometry.yaml
+    n_panels: 50                  # panels over the span; two sections make a panel
+    # LINEAR, COSINE, SPLIT_PROVIDED, UNCHANGED or BILLOWING
+    spanwise_panel_distribution: LINEAR
+    spanwise_direction: [0, 1, 0] # unit vector along the span, in the CAD frame
+    remove_nan: true              # interpolate over NaN entries in the polar tables
+    use_prior_polar: false        # reuse polars on disk instead of regenerating them
+    billowing_percentage: 0.0     # trailing-edge billow, as % of arc length
+    crease_frac: 0.75             # chordwise position of the deflection hinge [-]
+
+    mesh:                         # how the sections were sliced from a CAD mesh
+      obj_file: data/ram_air_kite/ram_air_kite.obj  # the mesh sections come from
+      n_sections: 45              # sections sliced from the mesh
+      n_bins: 60                  # leading-edge stations marched across the span
+      # rows of the mesh-to-slicer rotation, whose x = chord, y = span, z = up
+      rotation: [[0, 0, -1], [-1, 0, 0], [0, 1, 0]]
+      wingtip_distance: 0.0       # arc length the outermost sections stop short [m]
+      clearance: 0.006            # shrink-wrap offset outside the cloud [chord fraction]
+      min_concave_radius: 0.02    # shrink-wrap rolling-ball radius [chord fraction]
+
+    airfoil:                      # the 2D backend and the polars it tabulates
+      solver: xfoil               # section backend: neuralfoil or xfoil
+      model_size: large           # NeuralFoil network size
+      n_crit: 9.0                 # e^N transition criticality; lower transitions earlier
+      xtr_upper: 0.05             # forced upper-surface transition [chord fraction]
+      xtr_lower: 0.05             # forced lower-surface transition [chord fraction]
+      alpha_range: [-180, 1, 180] # angle-of-attack sweep [°] as [first, step, last]
+      delta_range: [-40, 10, 40]  # flap-deflection sweep [°]; null for no flap sweep
+      # angles off the reference angle a live polar is re-solved at [°]
+      live_offsets: [-12, -9, -6, -3, 0, 3, 6, 9, 12]
+      v_app: 25.0                 # apparent wind the Reynolds number is taken at [m/s]
+      chord_ref: 1.0              # reference (maximum panel) chord [m]
+      table_format: arrow         # per-node table format: csv or arrow
+
+solver_settings:
+  aerodynamic_model_type: VSM     # VSM or LLT
+  type_initial_gamma_distribution: ELLIPTIC  # ELLIPTIC or ZEROS
+  solver_type: LOOP               # LOOP or NONLIN
+  density: 1.225                  # air density [kg/m³]
+  mu: 1.81e-5                     # dynamic viscosity [N·s/m²]
+  rtol: 1e-6                      # relative tolerance on the circulation residual [-]
+  relaxation_factor: 0.01         # under-relaxation of the circulation update [-]
+```
+
+[`SolverSettings`](@ref) lists the rest of `solver_settings:`; a key left out keeps its
+default. `n_panels` given there is ignored — the total is summed from the wings.
+
+## `mesh:`
+
+[`MeshSettings`](@ref) — which `.obj` mesh a wing's sections were cut from, and how.
+The block's `obj_file` is the mesh the sections are *generated from*, an input to the
+`geometry_file` the wing then flies; a wing's own top-level `obj_file` is a different
+route — straight from a mesh and a `.dat`, with no polar generation — and cannot be
+given alongside `geometry_file`.
+
+[`rotation_matrix`](@ref), [`slice_args`](@ref) and [`preview_args`](@ref) turn the
+block into the arguments
+[`obj_to_yaml`](@ref VortexStepMethod.ObjAdapter.obj_to_yaml) and
+[`plot_slices_3d`](@ref) take, and [`ShrinkWrap`](@ref) is built from `clearance` and
+`min_concave_radius`. A wing naming no `mesh:` block slices exactly as an
+unconfigured `obj_to_yaml` call does. [From CAD mesh to aerodynamic model](@ref)
+walks through what those arguments do.
+
+## `airfoil:`
+
+[`AirfoilSettings`](@ref) — the 2D section backend and the polars it tabulates.
+`solver:` chooses the viscous panel code (`xfoil`) or the neural surrogate
+(`neuralfoil`) for a whole dataset from the file, and [`airfoil_solver`](@ref)
+returns the [`XFoilSolver`](@ref) or [`NeuralFoilSolver`](@ref) it names.
+
+One block answers for both the tables a mesh is sliced into and the live polars a
+deformed section is re-solved on, so the two cannot be generated at different
+transition settings or off different networks. [`alpha_range`](@ref),
+[`delta_range`](@ref) and [`reynolds`](@ref) turn the sweeps and the
+`density * v_app * chord_ref / mu` reference into what the polar generator takes.

--- a/test/settings/test_settings.jl
+++ b/test/settings/test_settings.jl
@@ -83,6 +83,26 @@ end
     @test_throws Exception VortexStepMethod.airfoil_settings(Dict("n_crt" => 4.0))
 end
 
+@testset "the documented settings file loads" begin
+    page = joinpath(dirname(dirname(@__DIR__)), "docs", "src", "settings.md")
+    lines = readlines(page)
+    opening = findfirst(==("```yaml"), lines)
+    closing = findnext(==("```"), lines, opening + 1)
+    path = tempname() * ".yaml"
+    write(path, join(lines[opening+1:closing-1], "\n"))
+
+    set = VSMSettings(path; data_prefix = false)
+    wing = set.wings[1]
+    @test rotation_matrix(wing.mesh) == [0 0 -1; -1 0 0; 0 1 0]
+    @test airfoil_solver(wing.airfoil) isa VortexStepMethod.AirfoilAero.XFoilSolver
+    @test set.solver_settings.n_panels == wing.n_panels
+
+    # a field added to either block is a field the page does not yet describe
+    block = VortexStepMethod.YAML.load_file(path)["wings"][1]
+    @test Set(Symbol.(keys(block["mesh"]))) == Set(fieldnames(MeshSettings))
+    @test Set(Symbol.(keys(block["airfoil"]))) == Set(fieldnames(AirfoilSettings))
+end
+
 @testset "an unnamed mesh block slices as an unconfigured call" begin
     vertices, faces = ObjAdapter.read_faces(joinpath(ram_air_dir,
                                                     "ram_air_kite_body.obj"))


### PR DESCRIPTION
### TL;DR

`MeshSettings` and `AirfoilSettings` were rendered on the API pages, but no `.md` page anywhere showed a reader the file those blocks live in — so `mesh:`, `airfoil:` and `solver: xfoil` were reachable only by opening a docstring and guessing the YAML around it. This adds `docs/src/settings.md`, an annotated `vsm_settings.yaml` the docs build renders and the test suite loads.

### The red check is #300, not this diff

`Test end-user and developer setup` is red here, and it is not this change: this branch is +139 / −0 across `README.md`, `docs/make.jl`, `docs/src/index.md`, `docs/src/settings.md` and `test/settings/test_settings.jl`, with no Julia source in it at all, and that job neither builds the docs nor runs `test/settings/`.

What fails is `examples/ram_air_kite.jl:79` — `plot_slices_3d` → `fit_kulfan_parameters` → `normalize_airfoil` at `src/airfoil_aero/kulfan.jl:71`, `ArgumentError: reducing over an empty collection is not allowed`, the empty `argmin` you get when `read_dat_coordinates` finds a deflected `.dat` that is all `NaN NaN` rows. That is issue #300, whose fix is open as #301.

I checked it against a branch that shares no code with this one rather than inferring it: #305 changes `bin/release` and nothing else, and its run fails the same job on the same example with the same error and the same `15 passed, 1 failed`. The same job is red right now on #302, #306, #301 and #273 too. Every other check on this PR that has finished is green, including `Documentation`, which is the one that actually exercises the page this PR adds.

I am not fixing it here. It is a `src/` bug with its own issue and its own open PR, and pulling it into a docs diff would put two ideas in one PR and take the fix away from the reviewer who has the context for it.

### What the page is

One annotated file, all three top-level blocks, with a wing carrying both `mesh:` and `airfoil:` annotated field by field. Every field of both blocks appears, because that is the gap the issue names: showing the block and deferring to the docstring for its contents would have moved the problem, not closed it. The split I kept instead is the one `CLEAN_CODE.md` §3 prescribes for data files — the YAML comment gives a field's meaning, unit and allowed values, and the linked docstring keeps the defaults and the prose. `solver_settings:` is the exception: the file needs the block to be real, so the sample shows the two keys that are genuinely required plus a representative few, and points at [`SolverSettings`](@ref) for the rest rather than opening a second field reference.

Three things the page says that a reader could not have worked out from the docstrings: `geometry_file` resolves against the working directory while the settings path itself resolves under `data/`; `mesh: obj_file:` is the mesh sections are *generated from* and is not the wing's own top-level `obj_file`, which cannot sit beside `geometry_file`; and `n_panels` written under `solver_settings:` is discarded and recomputed as the sum over the wings.

### The sample is executed, not typed

A YAML sample in a markdown file rots silently, so the suite loads this one. `test/settings/test_settings.jl` extracts the page's own ```yaml fence, parses it, and — the part that actually bites — asserts the key sets of `mesh:` and `airfoil:` equal `fieldnames(MeshSettings)` and `fieldnames(AirfoilSettings)`. A field added to either struct now fails the suite instead of quietly leaving the page a field short. I checked that it bites rather than assuming it: deleting `n_bins: 60` from the page turns the testset red at 4 passed, 1 failed.

The existing `mesh and airfoil blocks` testset already covers the parsing itself, so the new one asserts only what is specific to the page and does not restate it.

### Where I would push back

No `CHANGELOG.md` entry. This is documentation with no behaviour change, and #302 is holding that file for the v5.1.0 release; adding a line there would conflict for no gain. Say the word if you would rather see it under a Documentation heading and I will add it after #302 merges.

I also added the pointer line to `docs/src/index.md` as well as `README.md`, though the issue asked only for the README. The two files carry that input section identically, and updating one would have left the docs home — the page next door to the new one — as the only place still not mentioning it.

### Found, not fixed

- `ConditionSettings` is unexported and has no docstring, so `condition:` is the one block the page cannot `@ref`. Its four fields are annotated in the sample instead. Giving it a docstring is a `src/` change and a second idea.
- The shipped `data/*/vsm_settings.yaml` files carry 20–35-line explanatory headers that this page now duplicates, against `CLEAN_CODE.md` §3's two-line limit, and the two `ram_air_kite` files additionally carry decorative top-level `Model:` / `PanelDistribution:` / `InitialGammaDistribution:` blocks the parser never reads. That is a `cleanup:` PR; say if you want it queued.
- `Wing(::VSMSettings)` reads `settings.wings[1]` only, though `wings:` is a list and `vsm_settings_dual.yaml` ships two. I left this out of the page: it is `Wing`'s behaviour rather than the file's, but it will surprise someone who writes a second wing.
- `obj_to_yaml`'s own `table_format` default is `:csv` while `AirfoilSettings.table_format` defaults to `:arrow`, so the same dataset gets a different table format depending on which route configured it.

### Verification

- [x] Reproduced first, at `fb1eea7`: `git grep '```yaml' -- docs README.md` and `git grep -l 'mesh:' -- 'docs/src/*.md' README.md` both returned nothing, and `git grep 'solver: xfoil' -- '*.md'` matched only `CHANGELOG.md:38`
- [x] `test/settings/test_settings.jl` 33/33 pass on the current head `99b1815` (juliaserver, 9 + 17 + 5 + 2); new testset 5/5, and red at "4 passed, 1 failed" with `n_bins: 60` deleted from the page
- [x] Docs build clean · 20 cross-references on the new page resolve, 0 unresolved `@ref` in `docs/build/settings.html` · pre-existing size warnings on `private_functions.md` and `functions.md` only
- [x] Sample loads to the expected values: `solver: xfoil` → `XFoilSolver`, rotation rows → `[0 0 -1; -1 0 0; 0 1 0]`, sweeps → `-180.0:1.0:180.0` and `-40.0:10.0:40.0`, `reynolds` → 1.6919889502762433e6, `table_format` → `Symbol arrow`, `solver_settings.n_panels` → 50
- [x] Merged `origin/main` into the branch at `99b1815`; 0 commits behind, and the merge touched no file this PR adds · REUSE lint n/a, this repo has no `bin/reuse_lint`
- [x] Local full suite: PASS (6 min, Julia 1.12.7, one matrix cell) — run on `ca29dc5`, before the merge of main
- [x] GitHub CI on `99b1815`: `Documentation` PASS · Julia 1.12 pull_request PASS on ubuntu, macOS and windows · Julia 1.11 coverage PASS · `codecov/patch` PASS · `Test end-user and developer setup` FAIL for #300, evidence above · the two remaining coverage jobs were still running when this was written
- Benchmark: n/a
- Risk: the guard reads `docs/src/settings.md` by path, so the suite needs the repo checkout rather than a stripped install to run that testset.

### Scope

+139 / −0 across 5 files, of which `docs/src/settings.md` is 114. No `src/` change, no CHANGELOG entry (see above). Not stacked — of the open PRs only #301 touches `docs/src/` at all, and that is `private_functions.md`, no file this branch opens.

Closes #278 · task `VortexStepMethod.jl-278`
