### PR TITLE
Setup Test is failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
   `test/solver/solver_test_wing.yaml` wing at 26.6° it stopped 3.6% below `LOOP`'s
   peak circulation and reported `FAILURE`, and now lands on the same distribution
   with a fixed-point residual at machine precision.
+- `plot_slices_3d` in audit mode no longer crashes when a generated deflection
+  `.dat` holds no finite coordinates (an all-`NaN` contour from a deflection the
+  solver never converged): it warns and skips that overlay, as it already did
+  for a missing file.
 
 ## VortexStepMethod v5.0.0 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@
   with a fixed-point residual at machine precision.
 - `plot_slices_3d` in audit mode no longer crashes when a generated deflection
   `.dat` holds no finite coordinates (an all-`NaN` contour from a deflection the
-  solver never converged): it warns and skips that overlay, as it already did
-  for a missing file.
+  2D solver converged at no angle): it skips that overlay and warns, naming the
+  file and whether it was blank or missing.
 
 ## VortexStepMethod v5.0.0 2026-09-07
 

--- a/ext/VortexStepMethodMakieExt.jl
+++ b/ext/VortexStepMethodMakieExt.jl
@@ -1626,12 +1626,13 @@ function generated_slices(out_dir, delta, fit_pts)
         def3d = nothing
         if !iszero(delta)
             dpath = joinpath(out_dir, "airfoils", "$(id)$(tag)")
-            if isfile(dpath)
-                xd, yd = AirfoilAero.read_dat_coordinates(dpath)
+            xd, yd = isfile(dpath) ? AirfoilAero.read_dat_coordinates(dpath) :
+                     (Float64[], Float64[])
+            if isempty(xd)
+                push!(missing_deltas, basename(dpath))
+            else
                 def3d = map_airfoil_3d(les[i], tes[i], tangent, xd, yd)
                 d2 = (; d2..., def=Point2f.(xd, yd), def_kulfan=fit_pts(xd, yd))
-            else
-                push!(missing_deltas, basename(dpath))
             end
         end
         (; centroid=Point3f((les[i] .+ tes[i]) ./ 2), label_y=les[i][2],
@@ -1673,8 +1674,9 @@ function ObjAdapter.plot_slices_3d(path::String; n_slices::Int=10, rotation=I,
         wrap_method=AirfoilAero.ShrinkWrap(), delta=0.0, crease_frac=0.75,
         obj_path=nothing, is_show::Bool=true)
     kulfan_pts(k) = Point2f.(AirfoilAero.kulfan_to_coordinates(k; n_points=150)...)
-    fit_pts(x, y) = kulfan_pts(AirfoilAero.fit_kulfan_parameters(
-        x, y, AirfoilAero.LeastSquaresFit()))
+    fit_pts(x, y) = isempty(x) ? Point2f[] :
+        kulfan_pts(AirfoilAero.fit_kulfan_parameters(
+            x, y, AirfoilAero.LeastSquaresFit()))
     mesh_path = isdir(path) ? obj_path : path
     vertices = faces = nothing
     if mesh_path !== nothing

--- a/ext/VortexStepMethodMakieExt.jl
+++ b/ext/VortexStepMethodMakieExt.jl
@@ -1613,7 +1613,7 @@ function generated_slices(out_dir, delta, fit_pts)
     n = length(rows)
     deg = round(float(delta); digits=1)
     tag = "_d" * (deg == round(deg) ? string(Int(deg)) : string(deg)) * ".dat"
-    missing_deltas = String[]
+    skipped_deltas = String[]
     slices = map(1:n) do i
         id = rows[i][1]
         tangent = normalize(les[min(i + 1, n)] .- les[max(i - 1, 1)])
@@ -1626,10 +1626,12 @@ function generated_slices(out_dir, delta, fit_pts)
         def3d = nothing
         if !iszero(delta)
             dpath = joinpath(out_dir, "airfoils", "$(id)$(tag)")
-            xd, yd = isfile(dpath) ? AirfoilAero.read_dat_coordinates(dpath) :
+            found = isfile(dpath)
+            xd, yd = found ? AirfoilAero.read_dat_coordinates(dpath) :
                      (Float64[], Float64[])
             if isempty(xd)
-                push!(missing_deltas, basename(dpath))
+                push!(skipped_deltas, basename(dpath) *
+                      (found ? ": no finite coordinates" : ": no such file"))
             else
                 def3d = map_airfoil_3d(les[i], tes[i], tangent, xd, yd)
                 d2 = (; d2..., def=Point2f.(xd, yd), def_kulfan=fit_pts(xd, yd))
@@ -1639,9 +1641,11 @@ function generated_slices(out_dir, delta, fit_pts)
          cloud3d=map_airfoil_3d(les[i], tes[i], tangent, xr, yr),
          wrap3d=map_airfoil_3d(les[i], tes[i], tangent, xw, yw), def3d, d2)
     end
-    isempty(missing_deltas) ||
-        @warn "No generated .dat for delta=$(delta)° ($(join(missing_deltas, ", ")));" *
-              " generated deflections are named airfoils/<i>_d<degrees>.dat."
+    isempty(skipped_deltas) ||
+        @warn "Skipping the delta=$(delta)° overlay for" *
+              " $(join(skipped_deltas, ", ")); generated deflections are named" *
+              " airfoils/<i>_d<degrees>.dat, and a blank one is a deflection the 2D" *
+              " solver converged at no angle."
     return slices, reduce(hcat, les), reduce(hcat, tes)
 end
 

--- a/test/plotting/test_plotting.jl
+++ b/test/plotting/test_plotting.jl
@@ -503,4 +503,31 @@ end
     ax_lw = Axis3(fig_lw[1, 1])
     @test_nowarn Makie.plot!(ax_lw, plain_body; border_linewidth=3.0)
 end
+
+@testset "Audit slices (Makie)" begin
+    # An all-NaN deflected .dat reads as empty; the audit plot treats it as missing.
+    gen_dir, _ = ram_air_matrix_dir(; n_sections=4,
+        alpha_range=deg2rad.(-1:1.0:1), delta_range=deg2rad.(-1:1.0:1))
+    obj = joinpath(dirname(@__DIR__), "..", "data", "ram_air_kite",
+                   "ram_air_kite_body.obj")
+    audit_dir = joinpath(mktempdir(), "audit")
+    cp(gen_dir, audit_dir)
+    rows = YAML.load_file(joinpath(audit_dir, "geometry.yaml"))["wing_sections"]["data"]
+    d1 = joinpath(audit_dir, "airfoils", "$(rows[1][1])_d1.dat")
+    @test isfile(d1)
+    open(d1, "w") do io
+        println(io, "deflection")
+    end
+
+    slices, _, _ = makie_ext.generated_slices(audit_dir, 1.0, (x, y) -> Point2f[])
+    skipped = first(slices)
+    @test skipped.def3d === nothing
+    @test isempty(skipped.d2.def)
+    @test isempty(skipped.d2.def_kulfan)
+    @test any(s -> s.def3d !== nothing, slices)
+
+    fig = VortexStepMethod.ObjAdapter.plot_slices_3d(
+        audit_dir; delta=1.0, obj_path=obj, is_show=false)
+    @test fig isa Figure
+end
 nothing

--- a/test/plotting/test_plotting.jl
+++ b/test/plotting/test_plotting.jl
@@ -505,7 +505,7 @@ end
 end
 
 @testset "Audit slices (Makie)" begin
-    # An all-NaN deflected .dat reads as empty; the audit plot treats it as missing.
+    # An all-NaN deflected .dat reads as empty; here a header-only file stands in.
     gen_dir, _ = ram_air_matrix_dir(; n_sections=4,
         alpha_range=deg2rad.(-1:1.0:1), delta_range=deg2rad.(-1:1.0:1))
     obj = joinpath(dirname(@__DIR__), "..", "data", "ram_air_kite",
@@ -519,7 +519,8 @@ end
         println(io, "deflection")
     end
 
-    slices, _, _ = makie_ext.generated_slices(audit_dir, 1.0, (x, y) -> Point2f[])
+    slices, _, _ = @test_logs((:warn, r"no finite coordinates"), match_mode=:any,
+        makie_ext.generated_slices(audit_dir, 1.0, (x, y) -> Point2f[]))
     skipped = first(slices)
     @test skipped.def3d === nothing
     @test isempty(skipped.d2.def)


### PR DESCRIPTION
### TL;DR

The audit `plot_slices_3d` crashed on a generated deflection `.dat` that reads back with no coordinates, taking the whole `Setup Test` down with `ram_air_kite.jl`; it now skips that overlay and warns, naming the file and whether it was blank or absent.

### What was wrong

`ram_air_kite.jl:79` runs the audit plot over the generated `polars_xfoil` directory at `delta=1.0`. `generated_slices` read `airfoils/<id>_d1.dat`, got zero points back, and handed the empty contour to the Kulfan fit: `ArgumentError: reducing over an empty collection` out of `argmin` in `normalize_airfoil` (`src/airfoil_aero/kulfan.jl:71`), through `fit_pts` at `ext/VortexStepMethodMakieExt.jl:1676`. The file was there, so the `isfile` branch that already warns and draws nothing for a deflection that was never generated did not fire.

It reads back empty because it holds `NaN NaN` rows and `read_dat_coordinates` drops any line that does not start with a digit, `-` or `.`. A deflection column of `SectionAero.x` stays at its `fill(NaN, …)` initial value when no angle of that deflection lands a solution of the grid's modal node count (`src/airfoil_aero/section_aero_gen.jl:27-38`), and `write_section_aero` writes that column out unguarded — three lines above the guard that already refuses to write `{id}.dat` all-`NaN` for exactly this reason.

So the audit plot has two ways to have no deflected contour to draw and only handled one of them. It now handles both the same way, and the warning says which: `Skipping the delta=1.0° overlay for 4_d1.dat: no finite coordinates; …` against `… 4_d1.dat: no such file; …`.

### Is the blank column a regression in the wrapping under delta deflection?

Asked on the thread, and worth the check — a plot that skips a contour is a plot that can hide a bad one. I measured the deflected wrap directly rather than through the plot, on the example's own geometry and settings (10 slices of `ram_air_kite_body.obj`, `wingtip_distance=0.1`, `ShrinkWrap(clearance=0.0)`, `crease_frac=0.75`, `Re=1e6`, XFoil `npan=160`/`ncrit=9`/`xtrip=(0.05, 0.05)`, α = −8:2:26°).

Sections 1 and 10 are thrown out on thickness (0.424 against a 0.225 limit) before any deflection is formed — that is the `Reused the nearest valid airfoil for: section 1 → airfoil 2, section 10 → airfoil 9` line in the CI log, and it is about the raw tip slices, not about δ. For the eight sections that remain, the 1° deflected wrap is indistinguishable in health from the undeflected one: 239 contour nodes either way, no non-finite coordinate, chord normalised to [0, 1], no fold on either surface, enclosed area within 0.1% of δ=0, and XFoil converges at exactly the same 16–17 of the 18 angles. No blank column reproduces on this box at all.

That matches what the mechanism says it should be. The contour that reaches the `.dat` is `deform_section`'s own output — #301 measured XFoil handing it back unchanged at `repanel=false`, `max|dx| = max|dy| = 0.0` — so the shape never depends on the solver converging; only its *presence* does. A blank column therefore means "no angle of that deflection landed", not "the deflected wrap produced garbage". `generate_airfoils` validates only `sols[1]`, the δ=0 column (`src/airfoil_aero/geometry_gen.jl:48`), so a dead deflection column leaves no trace anywhere else.

<details>
<summary>Per-section numbers, δ=0 against δ=1°</summary>

```
sliced 10 sections; thickness limit 0.2253; degenerate: [1, 10]
section 2:  d=0  n=239 nonfinite=0 chord=[0.0000,1.0000] tmax=0.1155 area=0.12906 folds=0/0  converged 16/18
            d=1  n=239 nonfinite=0 chord=[0.0000,1.0000] tmax=0.1165 area=0.12915 folds=0/0  converged 16/18
section 3:  d=0  n=239 area=0.13949 folds=0/0  converged 16/18      d=1  n=239 area=0.13962 folds=0/0  converged 17/18
section 4:  d=0  n=239 area=0.13247 folds=0/0  converged 16/18      d=1  n=239 area=0.13256 folds=0/0  converged 16/18
section 5:  d=0  n=239 area=0.13016 folds=0/0  converged 17/18      d=1  n=239 area=0.13026 folds=0/0  converged 17/18
section 6:  d=0  n=239 area=0.13018 folds=0/0  converged 16/18      d=1  n=239 area=0.13028 folds=0/0  converged 16/18
section 7:  d=0  n=239 area=0.13249 folds=0/0  converged 16/18      d=1  n=239 area=0.13259 folds=0/0  converged 16/18
section 8:  d=0  n=239 area=0.13955 folds=0/0  converged 16/18      d=1  n=239 area=0.13967 folds=0/0  converged 16/18
section 9:  d=0  n=239 area=0.12914 folds=0/0  converged 17/18      d=1  n=239 area=0.12924 folds=0/0  converged 17/18
```

</details>

### What this change can and cannot hide

It cannot hide a wrong deflected contour. The skip fires only on a contour with no usable coordinate at all; anything finite is fitted and drawn exactly as before, and the `fit_pts` guard returns an empty point vector only for an input that previously threw. The deflected contour is also the only one that can reach it empty: `write_section_aero` already refuses to write `{id}.dat` all-`NaN`, and the live path's `shrink_wrap` throws rather than hand back nothing — so no overlay goes quiet without the warning above. What it does change is that a deflection the solver never landed now reaches the reader as a named warning rather than as a stack trace — and, after this round, as a warning that does not read like a missing file, which is the case #298 is about.

### Found on the way

`deform_section`'s docstring (`src/airfoil_aero/airfoil_solvers/common.jl:100-102`) still promises that the re-wrap "bridges the crease with a `min_concave_radius` fillet". Since `1e13d92` the wrap offsets the ball's contact polygon instead of sweeping its rim, so a concavity narrower than the ball is bridged *straight* (`src/airfoil_aero/shrink_wrap.jl:139-146`), and at the `clearance = 0.0` that path uses, the contour is the contact polygon itself. The crease geometry the solvers are handed is therefore not what that docstring says. It is behaviour-neutral to fix and in a file this diff has no other reason to open, so it is not in here.

The producer-side half — that `write_section_aero` writes the all-`NaN` column at all, and that `generate_airfoils` never notices a deflection that converged nowhere — is #300, open as #301. The two are complementary: with #301 merged the file is absent rather than blank and this plot takes its other branch, and until then (or for a directory generated before it) this is what stops the crash.

### Verification

- [x] Reproduced first: `ArgumentError: reducing over an empty collection` from `normalize_airfoil`/`argmin`, `ext/VortexStepMethodMakieExt.jl:1632` → `kulfan.jl:71`, identical to the `Setup Test` stack on run 34653119608
- [x] `test/plotting/test_plotting.jl` "Audit slices (Makie)" red before, green after (juliaserver): the empty-contour assertions errored before `4c799ad`; the warning assertion failed before `8ded002` with the old text `No generated .dat for delta=1.0° (4_d1.dat)`; now 7/7, file 84/84
- [x] Local full suite: PASS (7 min) on `8ded002` · GitHub CI on `8ded002`: `Setup Test` green, `CI` green on the rerun
- [x] The one red job on the first `CI` attempt was `test/solver/test_forwarddiff.jl`'s AD-against-finite-difference check, `relative_error = 0.0400` against `1e-4`, with `norm_fwd = 2.114327230856032` — #291's documented draw of the regenerated ram-air fixture, in code this diff does not touch (no `src/` change at all); green on rerun of that job alone
- [ ] Docs build: not run — no docstring, export or `docs/src` page changed
- Benchmark: n/a
- Risk: the blank column is a solver outcome that does not reproduce on this box, so the crash path itself is exercised only by the regression test's synthetic blank `.dat`, not by a generated one.

### Scope

+48 / −10 across 3 files: `ext/VortexStepMethodMakieExt.jl` (the skip and the warning), `test/plotting/test_plotting.jl` (the regression test), `CHANGELOG.md`. No stack; #301 touches the writer and the readers, not this.

Closes #311 · task `VortexStepMethod.jl-311`
