### PR TITLE
Fit the contour generate_airfoils is handed, not a second wrap of it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- `generate_airfoils` fits the contour it is handed rather than shrink-wrapping it a
+  second time. Both adapters wrap before they call, with the `wrap_method` their
+  settings name, so the second wrap discarded that setting and degenerated the Kulfan
+  fit: on the SK100's 45 mesh sections nine came out with `.dat` coordinates at 1e2 to
+  1e4 instead of 0..1, and any consumer mapping the mesh onto a structure rejected the
+  geometry.
+
 ## VortexStepMethod v5.1.0 2026-09-11
 
 ### Added
@@ -19,12 +30,6 @@
 
 ### Fixed
 
-- `generate_airfoils` fits the contour it is handed rather than shrink-wrapping it a
-  second time. Both adapters wrap before they call, with the `wrap_method` their
-  settings name, so the second wrap discarded that setting and degenerated the Kulfan
-  fit: on the SK100's 45 mesh sections nine came out with `.dat` coordinates at 1e2 to
-  1e4 instead of 0..1, and any consumer mapping the mesh onto a structure rejected the
-  geometry.
 - The `NONLIN` solver backtracks along each Newton step instead of always taking
   it whole, so it converges past stall where the full step used to cycle: on the
   `test/solver/solver_test_wing.yaml` wing at 26.6° it stopped 3.6% below `LOOP`'s

--- a/test/airfoil_aero/test_airfoil_aero.jl
+++ b/test/airfoil_aero/test_airfoil_aero.jl
@@ -283,8 +283,7 @@ end
         aero_solver=NeuralFoilSolver(model_size="medium"), verbose=false)
     @test ok == [1]
     _, written_y = read_dat_coords(joinpath(out, "airfoils", "1.dat"))
-    # A second shrink wrap inflates the section by its own clearance, 0.006, which is
-    # three orders of magnitude above the resampling error this tolerance allows.
+    # A second shrink wrap inflates the section by its clearance, 0.006 — 60x this bound.
     @test maximum(abs, collect(extrema(written_y)) .-
                        collect(extrema(fitted_y))) < 1e-4
 end


### PR DESCRIPTION
The red check was not this branch's, and it has since gone green on its own. `test/solver/test_forwarddiff.jl:87`, testset "AutoForwardDiff matches AutoFiniteDiff (LOOP, POLAR_MATRICES)", evaluated `relative_error(jac_fd, jac_fwd) = 0.04207 < 1e-4` on `4b261f0`. Re-running that same job on that same commit, without one line changed, turned it green — and with it all seven checks. The same testset had already failed twice on `main` before this branch existed, at 0.04001 (OpenSourceAWE/VortexStepMethod.jl@6af7183) and 0.040003 (OpenSourceAWE/VortexStepMethod.jl@fb1eea7). It is #287's flake, which #292 closed without removing; I reopened it with everything measured below.

Chasing it turned up one thing this change owes the reader. Fitting the contour `generate_airfoils` is handed drops the wingtip panel incidence at that test's operating point from **19.04/18.93 deg to 14.99/14.94 deg**, and `norm(jac_fwd)` from 2.21 to 3.30. The doubly-wrapped fit had been pushing the tips 4 deg past the polar table's top knot into `extrap_flat`, where `dcl/dalpha` is zero and a tip carries no alpha sensitivity at all. That is the fix working, on a wing this diff never touches.

It is not what makes the check flake, and neither is the finite-difference step #292 shrank. `rel_err` stays in 3e-8…5e-8 across solver `rtol` 1e-11…1e-7 crossed with steps 1e-8…1e-4 — flat, so nothing is trading truncation against solver noise. Walking the operating point across the knot the tips now sit under changes nothing either: 268 points (alpha 0:0.25:20 at zero sideslip, then alpha 5:0.5:10 crossed with beta -4:0.5:4) give a worst `rel_err` of **2.3e-7**. What is left is the fixture, #291 — the failing runner reported `norm(jac_fwd) = 3.28551` where this box gets `3.29711` on the same commit, so it was not generating the same NeuralFoil tables. That axis cannot be walked from here.

One loose end this merge left behind: v5.1.0 was cut while the branch was open, so `CHANGELOG.md` on `main` now files this fix under `## VortexStepMethod v5.1.0 2026-09-11`, a release that shipped without it. The two commits that put it back under `## Unreleased` (OpenSourceAWE/VortexStepMethod.jl@5a4b7ec, and @a820826 folding a two-line inline comment into one) landed on the branch after the merge. Queued as #313 to cherry-pick.

### Verification

- [x] CI: re-run of `Julia 1.12 - ubuntu-latest - x64 - pull_request` on `4b261f0`, no code change — green, all seven checks green on that commit
- [x] `test/airfoil_aero/test_airfoil_aero.jl` green with `main` merged in, incl. `generate_airfoils fits the wrapped contour it is handed | 2 2` (juliaserver, tables regenerated)
- [x] `test/solver/test_forwarddiff.jl` green here, 7/7, `rel_err = 4.84e-8` — 2000x inside the bound CI missed
- Risk: the ~0.040 jump is still unexplained, so the check can come back red on a runner whose generated tables differ. Nothing here makes that likelier — `main`'s doubly-wrapped fit measures 4.80e-8 on this box against this branch's 4.84e-8.

Task `VortexStepMethod.jl-294`
